### PR TITLE
Add weather and network dashboards with Open-Meteo API

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -37,6 +37,12 @@ const demos = [
     category: 'Dashboards',
   },
   {
+    route: '/network-dashboard',
+    title: 'Network Administration Dashboard',
+    description: 'Network traffic and device management.',
+    category: 'Dashboards',
+  },
+  {
     route: '/delete-one-click',
     title: 'One-click Delete',
     description: 'Delete with a single click.',

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -31,6 +31,12 @@ const demos = [
   },
   { route: '/dashboard', title: 'Service Dashboard', description: 'Dashboard layout demo.', category: 'Dashboards' },
   {
+    route: '/weather-dashboard',
+    title: 'Weather Dashboard',
+    description: 'Real-time weather via Open-Meteo.',
+    category: 'Dashboards',
+  },
+  {
     route: '/delete-one-click',
     title: 'One-click Delete',
     description: 'Delete with a single click.',

--- a/src/pages/network-dashboard/app.tsx
+++ b/src/pages/network-dashboard/app.tsx
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useRef, useState } from 'react';
+import { AppLayoutProps } from '@cloudscape-design/components/app-layout';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { Breadcrumbs, Notifications } from '../commons';
+import { CustomAppLayout } from '../commons/common-components';
+import { NetworkContent } from './content';
+
+export function App() {
+  const appLayout = useRef<AppLayoutProps.Ref>(null);
+  const [toolsOpen, setToolsOpen] = useState(false);
+
+  return (
+    <CustomAppLayout
+      ref={appLayout}
+      content={
+        <SpaceBetween size="m">
+          <NetworkContent />
+        </SpaceBetween>
+      }
+      breadcrumbs={<Breadcrumbs items={[{ text: 'Administrative Dashboard', href: '#/' }]} />}
+      toolsHide
+      navigationHide
+      toolsOpen={toolsOpen}
+      onToolsChange={({ detail }) => setToolsOpen(detail.open)}
+      notifications={<Notifications />}
+    />
+  );
+}

--- a/src/pages/network-dashboard/content.tsx
+++ b/src/pages/network-dashboard/content.tsx
@@ -10,7 +10,7 @@ import Button from '@cloudscape-design/components/button';
 import TextFilter from '@cloudscape-design/components/text-filter';
 import Pagination from '@cloudscape-design/components/pagination';
 import Table from '@cloudscape-design/components/table';
-import Flashbar from '@cloudscape-design/components/flashbar';
+import Alert from '@cloudscape-design/components/alert';
 import AreaChart from '@cloudscape-design/components/area-chart';
 import BarChart from '@cloudscape-design/components/bar-chart';
 import StatusIndicator from '@cloudscape-design/components/status-indicator';
@@ -164,17 +164,14 @@ export function NetworkContent() {
       </Header>
 
       {!warningDismissed && (
-        <Flashbar
-          items={[
-            {
-              type: 'error',
-              content: 'This is a warning message',
-              dismissible: true,
-              onDismiss: () => setWarningDismissed(true),
-              dismissLabel: 'Dismiss',
-            },
-          ]}
-        />
+        <Alert
+          type="error"
+          dismissible
+          onDismiss={() => setWarningDismissed(true)}
+          dismissAriaLabel="Dismiss"
+        >
+          This is a warning message
+        </Alert>
       )}
 
       <Grid gridDefinition={[{ colspan: { default: 12, m: 6 } }, { colspan: { default: 12, m: 6 } }]}>

--- a/src/pages/network-dashboard/content.tsx
+++ b/src/pages/network-dashboard/content.tsx
@@ -164,12 +164,7 @@ export function NetworkContent() {
       </Header>
 
       {!warningDismissed && (
-        <Alert
-          type="error"
-          dismissible
-          onDismiss={() => setWarningDismissed(true)}
-          dismissAriaLabel="Dismiss"
-        >
+        <Alert type="error" dismissible onDismiss={() => setWarningDismissed(true)} dismissAriaLabel="Dismiss">
           This is a warning message
         </Alert>
       )}

--- a/src/pages/network-dashboard/content.tsx
+++ b/src/pages/network-dashboard/content.tsx
@@ -103,7 +103,7 @@ export function NetworkContent() {
         <Flashbar
           items={[
             {
-              type: 'warning',
+              type: 'error',
               content: 'This is a warning message',
               dismissible: true,
               onDismiss: () => setWarningDismissed(true),

--- a/src/pages/network-dashboard/content.tsx
+++ b/src/pages/network-dashboard/content.tsx
@@ -42,14 +42,78 @@ const creditUsageData = [
 
 // Mock data for devices table
 const devicesData = [
-  { id: '1', name: 'Router-Main', type: 'Router', status: 'Online', ip: '192.168.1.1', mac: '00:1B:44:11:3A:B7', location: 'Office' },
-  { id: '2', name: 'Switch-Floor1', type: 'Switch', status: 'Online', ip: '192.168.1.10', mac: '00:1B:44:11:3A:B8', location: 'Floor 1' },
-  { id: '3', name: 'AP-Conference', type: 'Access Point', status: 'Warning', ip: '192.168.1.20', mac: '00:1B:44:11:3A:B9', location: 'Conference Room' },
-  { id: '4', name: 'Printer-Office', type: 'Printer', status: 'Online', ip: '192.168.1.50', mac: '00:1B:44:11:3A:C0', location: 'Office' },
-  { id: '5', name: 'Server-NAS', type: 'NAS', status: 'Online', ip: '192.168.1.100', mac: '00:1B:44:11:3A:C1', location: 'Server Room' },
-  { id: '6', name: 'Camera-Front', type: 'IP Camera', status: 'Offline', ip: '192.168.1.201', mac: '00:1B:44:11:3A:C2', location: 'Front Door' },
-  { id: '7', name: 'Smart-TV', type: 'Smart TV', status: 'Online', ip: '192.168.1.75', mac: '00:1B:44:11:3A:C3', location: 'Living Room' },
-  { id: '8', name: 'Laptop-John', type: 'Laptop', status: 'Online', ip: '192.168.1.150', mac: '00:1B:44:11:3A:C4', location: 'Home Office' },
+  {
+    id: '1',
+    name: 'Router-Main',
+    type: 'Router',
+    status: 'Online',
+    ip: '192.168.1.1',
+    mac: '00:1B:44:11:3A:B7',
+    location: 'Office',
+  },
+  {
+    id: '2',
+    name: 'Switch-Floor1',
+    type: 'Switch',
+    status: 'Online',
+    ip: '192.168.1.10',
+    mac: '00:1B:44:11:3A:B8',
+    location: 'Floor 1',
+  },
+  {
+    id: '3',
+    name: 'AP-Conference',
+    type: 'Access Point',
+    status: 'Warning',
+    ip: '192.168.1.20',
+    mac: '00:1B:44:11:3A:B9',
+    location: 'Conference Room',
+  },
+  {
+    id: '4',
+    name: 'Printer-Office',
+    type: 'Printer',
+    status: 'Online',
+    ip: '192.168.1.50',
+    mac: '00:1B:44:11:3A:C0',
+    location: 'Office',
+  },
+  {
+    id: '5',
+    name: 'Server-NAS',
+    type: 'NAS',
+    status: 'Online',
+    ip: '192.168.1.100',
+    mac: '00:1B:44:11:3A:C1',
+    location: 'Server Room',
+  },
+  {
+    id: '6',
+    name: 'Camera-Front',
+    type: 'IP Camera',
+    status: 'Offline',
+    ip: '192.168.1.201',
+    mac: '00:1B:44:11:3A:C2',
+    location: 'Front Door',
+  },
+  {
+    id: '7',
+    name: 'Smart-TV',
+    type: 'Smart TV',
+    status: 'Online',
+    ip: '192.168.1.75',
+    mac: '00:1B:44:11:3A:C3',
+    location: 'Living Room',
+  },
+  {
+    id: '8',
+    name: 'Laptop-John',
+    type: 'Laptop',
+    status: 'Online',
+    ip: '192.168.1.150',
+    mac: '00:1B:44:11:3A:C4',
+    location: 'Home Office',
+  },
 ];
 
 export function NetworkContent() {
@@ -64,12 +128,12 @@ export function NetworkContent() {
       device.name.toLowerCase().includes(filterText.toLowerCase()) ||
       device.type.toLowerCase().includes(filterText.toLowerCase()) ||
       device.ip.includes(filterText) ||
-      device.location.toLowerCase().includes(filterText.toLowerCase())
+      device.location.toLowerCase().includes(filterText.toLowerCase()),
   );
 
   const paginatedDevices = filteredDevices.slice(
     (currentPageIndex - 1) * itemsPerPage,
-    currentPageIndex * itemsPerPage
+    currentPageIndex * itemsPerPage,
   );
 
   const getStatusIcon = (status: string) => {
@@ -270,7 +334,12 @@ export function NetworkContent() {
             columnDefinitions={[
               { id: 'name', header: 'Device Name', cell: (item: any) => item.name, sortingField: 'name' },
               { id: 'type', header: 'Type', cell: (item: any) => item.type, sortingField: 'type' },
-              { id: 'status', header: 'Status', cell: (item: any) => getStatusIcon(item.status), sortingField: 'status' },
+              {
+                id: 'status',
+                header: 'Status',
+                cell: (item: any) => getStatusIcon(item.status),
+                sortingField: 'status',
+              },
               { id: 'ip', header: 'IP Address', cell: (item: any) => item.ip, sortingField: 'ip' },
               { id: 'mac', header: 'MAC Address', cell: (item: any) => item.mac, sortingField: 'mac' },
               { id: 'location', header: 'Location', cell: (item: any) => item.location, sortingField: 'location' },
@@ -300,7 +369,13 @@ export function NetworkContent() {
               />
             }
             header={
-              <Header counter={selectedItems.length ? `(${selectedItems.length}/${filteredDevices.length})` : `(${filteredDevices.length})`}>
+              <Header
+                counter={
+                  selectedItems.length
+                    ? `(${selectedItems.length}/${filteredDevices.length})`
+                    : `(${filteredDevices.length})`
+                }
+              >
                 Network Devices
               </Header>
             }

--- a/src/pages/network-dashboard/content.tsx
+++ b/src/pages/network-dashboard/content.tsx
@@ -1,0 +1,324 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState } from 'react';
+import Header from '@cloudscape-design/components/header';
+import Container from '@cloudscape-design/components/container';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Grid from '@cloudscape-design/components/grid';
+import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
+import TextFilter from '@cloudscape-design/components/text-filter';
+import Pagination from '@cloudscape-design/components/pagination';
+import Table from '@cloudscape-design/components/table';
+import Flashbar from '@cloudscape-design/components/flashbar';
+import AreaChart from '@cloudscape-design/components/area-chart';
+import BarChart from '@cloudscape-design/components/bar-chart';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+
+// Mock data for network traffic
+const networkTrafficData = [
+  { x: 'x1', site1: 85, site2: 45 },
+  { x: 'x2', site1: 90, site2: 52 },
+  { x: 'x3', site1: 88, site2: 48 },
+  { x: 'x4', site1: 92, site2: 55 },
+  { x: 'x5', site1: 87, site2: 50 },
+  { x: 'x6', site1: 95, site2: 58 },
+  { x: 'x7', site1: 89, site2: 53 },
+  { x: 'x8', site1: 93, site2: 56 },
+  { x: 'x9', site1: 91, site2: 54 },
+  { x: 'x10', site1: 88, site2: 51 },
+  { x: 'x11', site1: 94, site2: 57 },
+  { x: 'x12', site1: 90, site2: 52 },
+];
+
+// Mock data for credit usage
+const creditUsageData = [
+  { x: 'x1', usage: 120 },
+  { x: 'x2', usage: 180 },
+  { x: 'x3', usage: 150 },
+  { x: 'x4', usage: 90 },
+  { x: 'x5', usage: 160 },
+];
+
+// Mock data for devices table
+const devicesData = [
+  { id: '1', name: 'Router-Main', type: 'Router', status: 'Online', ip: '192.168.1.1', mac: '00:1B:44:11:3A:B7', location: 'Office' },
+  { id: '2', name: 'Switch-Floor1', type: 'Switch', status: 'Online', ip: '192.168.1.10', mac: '00:1B:44:11:3A:B8', location: 'Floor 1' },
+  { id: '3', name: 'AP-Conference', type: 'Access Point', status: 'Warning', ip: '192.168.1.20', mac: '00:1B:44:11:3A:B9', location: 'Conference Room' },
+  { id: '4', name: 'Printer-Office', type: 'Printer', status: 'Online', ip: '192.168.1.50', mac: '00:1B:44:11:3A:C0', location: 'Office' },
+  { id: '5', name: 'Server-NAS', type: 'NAS', status: 'Online', ip: '192.168.1.100', mac: '00:1B:44:11:3A:C1', location: 'Server Room' },
+  { id: '6', name: 'Camera-Front', type: 'IP Camera', status: 'Offline', ip: '192.168.1.201', mac: '00:1B:44:11:3A:C2', location: 'Front Door' },
+  { id: '7', name: 'Smart-TV', type: 'Smart TV', status: 'Online', ip: '192.168.1.75', mac: '00:1B:44:11:3A:C3', location: 'Living Room' },
+  { id: '8', name: 'Laptop-John', type: 'Laptop', status: 'Online', ip: '192.168.1.150', mac: '00:1B:44:11:3A:C4', location: 'Home Office' },
+];
+
+export function NetworkContent() {
+  const [filterText, setFilterText] = useState('');
+  const [currentPageIndex, setCurrentPageIndex] = useState(1);
+  const [selectedItems, setSelectedItems] = useState<any[]>([]);
+  const [warningDismissed, setWarningDismissed] = useState(false);
+  const itemsPerPage = 10;
+
+  const filteredDevices = devicesData.filter(
+    device =>
+      device.name.toLowerCase().includes(filterText.toLowerCase()) ||
+      device.type.toLowerCase().includes(filterText.toLowerCase()) ||
+      device.ip.includes(filterText) ||
+      device.location.toLowerCase().includes(filterText.toLowerCase())
+  );
+
+  const paginatedDevices = filteredDevices.slice(
+    (currentPageIndex - 1) * itemsPerPage,
+    currentPageIndex * itemsPerPage
+  );
+
+  const getStatusIcon = (status: string) => {
+    switch (status) {
+      case 'Online':
+        return <StatusIndicator type="success">Online</StatusIndicator>;
+      case 'Warning':
+        return <StatusIndicator type="warning">Warning</StatusIndicator>;
+      case 'Offline':
+        return <StatusIndicator type="error">Offline</StatusIndicator>;
+      default:
+        return <StatusIndicator type="pending">Unknown</StatusIndicator>;
+    }
+  };
+
+  return (
+    <SpaceBetween size="l">
+      <Header
+        variant="h1"
+        description="Network Traffic, Credit Usage, and Your Devices"
+        actions={
+          <Button variant="primary" iconName="external" iconAlign="right">
+            Refresh Data
+          </Button>
+        }
+      >
+        Network Administration Dashboard
+      </Header>
+
+      {!warningDismissed && (
+        <Flashbar
+          items={[
+            {
+              type: 'warning',
+              content: 'This is a warning message',
+              dismissible: true,
+              onDismiss: () => setWarningDismissed(true),
+              dismissLabel: 'Dismiss',
+            },
+          ]}
+        />
+      )}
+
+      <Grid gridDefinition={[{ colspan: { default: 12, m: 6 } }, { colspan: { default: 12, m: 6 } }]}>
+        <Container>
+          <AreaChart
+            series={[
+              {
+                title: 'Site 1',
+                type: 'area',
+                data: networkTrafficData.map(d => ({ x: d.x, y: d.site1 })),
+                color: '#688AE8',
+              },
+              {
+                title: 'Site 2',
+                type: 'area',
+                data: networkTrafficData.map(d => ({ x: d.x, y: d.site2 })),
+                color: '#C33D69',
+              },
+            ]}
+            xDomain={networkTrafficData.map(d => d.x)}
+            yDomain={[0, 100]}
+            i18nStrings={{
+              filterLabel: 'Filter displayed data',
+              filterPlaceholder: 'Filter data',
+              filterSelectedAriaLabel: 'selected',
+              legendAriaLabel: 'Legend',
+              chartAriaRoleDescription: 'area chart',
+              xTickFormatter: e => e,
+              yTickFormatter: e => `${e}`,
+            }}
+            ariaLabel="Network traffic area chart"
+            errorText="Error loading data."
+            height={300}
+            loadingText="Loading chart"
+            recoveryText="Retry"
+            xScaleType="categorical"
+            yScaleType="linear"
+            xTitle="Day"
+            yTitle="Network traffic"
+            empty={
+              <Box textAlign="center" color="inherit">
+                <b>No data available</b>
+                <Box variant="p" color="inherit">
+                  There is no data available
+                </Box>
+              </Box>
+            }
+            noMatch={
+              <Box textAlign="center" color="inherit">
+                <b>No matching data</b>
+                <Box variant="p" color="inherit">
+                  There is no matching data to display
+                </Box>
+              </Box>
+            }
+          />
+        </Container>
+
+        <Container>
+          <BarChart
+            series={[
+              {
+                title: 'Site 1',
+                type: 'bar',
+                data: creditUsageData.map(d => ({ x: d.x, y: d.usage })),
+                color: '#688AE8',
+              },
+            ]}
+            xDomain={creditUsageData.map(d => d.x)}
+            yDomain={[0, 200]}
+            i18nStrings={{
+              filterLabel: 'Filter displayed data',
+              filterPlaceholder: 'Filter data',
+              filterSelectedAriaLabel: 'selected',
+              legendAriaLabel: 'Legend',
+              chartAriaRoleDescription: 'bar chart',
+              xTickFormatter: e => e,
+              yTickFormatter: e => `${e}`,
+            }}
+            ariaLabel="Credit usage bar chart"
+            errorText="Error loading data."
+            height={300}
+            loadingText="Loading chart"
+            recoveryText="Retry"
+            xScaleType="categorical"
+            yScaleType="linear"
+            xTitle="Day"
+            yTitle="Credit Usage"
+            empty={
+              <Box textAlign="center" color="inherit">
+                <b>No data available</b>
+                <Box variant="p" color="inherit">
+                  There is no data available
+                </Box>
+              </Box>
+            }
+            noMatch={
+              <Box textAlign="center" color="inherit">
+                <b>No matching data</b>
+                <Box variant="p" color="inherit">
+                  There is no matching data to display
+                </Box>
+              </Box>
+            }
+          />
+        </Container>
+      </Grid>
+
+      <Container
+        header={
+          <Header
+            variant="h2"
+            description="Devices on your local network"
+            actions={
+              <Button variant="primary" iconName="external" iconAlign="right">
+                Add Device
+              </Button>
+            }
+          >
+            My Devices
+          </Header>
+        }
+      >
+        <SpaceBetween size="m">
+          <Grid gridDefinition={[{ colspan: { default: 12, s: 8, m: 6 } }, { colspan: { default: 12, s: 4, m: 6 } }]}>
+            <TextFilter
+              filteringText={filterText}
+              filteringPlaceholder="Placeholder"
+              filteringAriaLabel="Filter devices"
+              countText={`${filteredDevices.length} matches`}
+              onChange={({ detail }) => {
+                setFilterText(detail.filteringText);
+                setCurrentPageIndex(1);
+              }}
+            />
+            <Box textAlign="right">
+              <Pagination
+                currentPageIndex={currentPageIndex}
+                onChange={({ detail }) => setCurrentPageIndex(detail.currentPageIndex)}
+                pagesCount={Math.ceil(filteredDevices.length / itemsPerPage)}
+                ariaLabels={{
+                  nextPageLabel: 'Next page',
+                  previousPageLabel: 'Previous page',
+                  pageLabel: pageNumber => `Page ${pageNumber}`,
+                }}
+              />
+            </Box>
+          </Grid>
+
+          <Table
+            trackBy="id"
+            items={paginatedDevices}
+            loadingText="Loading devices"
+            selectedItems={selectedItems}
+            onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
+            selectionType="multi"
+            columnDefinitions={[
+              { id: 'name', header: 'Device Name', cell: (item: any) => item.name, sortingField: 'name' },
+              { id: 'type', header: 'Type', cell: (item: any) => item.type, sortingField: 'type' },
+              { id: 'status', header: 'Status', cell: (item: any) => getStatusIcon(item.status), sortingField: 'status' },
+              { id: 'ip', header: 'IP Address', cell: (item: any) => item.ip, sortingField: 'ip' },
+              { id: 'mac', header: 'MAC Address', cell: (item: any) => item.mac, sortingField: 'mac' },
+              { id: 'location', header: 'Location', cell: (item: any) => item.location, sortingField: 'location' },
+            ]}
+            empty={
+              <Box textAlign="center" color="inherit" margin={{ vertical: 'xs' }}>
+                <SpaceBetween size="xxs">
+                  <div>
+                    <b>No devices</b>
+                    <Box variant="p" color="inherit">
+                      No devices found on your network.
+                    </Box>
+                  </div>
+                  <Button>Add Device</Button>
+                </SpaceBetween>
+              </Box>
+            }
+            filter={
+              <TextFilter
+                filteringText={filterText}
+                filteringPlaceholder="Search devices"
+                filteringAriaLabel="Filter devices"
+                onChange={({ detail }) => {
+                  setFilterText(detail.filteringText);
+                  setCurrentPageIndex(1);
+                }}
+              />
+            }
+            header={
+              <Header counter={selectedItems.length ? `(${selectedItems.length}/${filteredDevices.length})` : `(${filteredDevices.length})`}>
+                Network Devices
+              </Header>
+            }
+            pagination={
+              <Pagination
+                currentPageIndex={currentPageIndex}
+                onChange={({ detail }) => setCurrentPageIndex(detail.currentPageIndex)}
+                pagesCount={Math.ceil(filteredDevices.length / itemsPerPage)}
+                ariaLabels={{
+                  nextPageLabel: 'Next page',
+                  previousPageLabel: 'Previous page',
+                  pageLabel: pageNumber => `Page ${pageNumber}`,
+                }}
+              />
+            }
+          />
+        </SpaceBetween>
+      </Container>
+    </SpaceBetween>
+  );
+}

--- a/src/pages/network-dashboard/index.tsx
+++ b/src/pages/network-dashboard/index.tsx
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import { App } from './app';
+
+import '../../styles/base.scss';
+
+export default function NetworkDashboardDemo() {
+  return <App />;
+}

--- a/src/pages/weather-dashboard/app.tsx
+++ b/src/pages/weather-dashboard/app.tsx
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useRef, useState } from 'react';
+import { AppLayoutProps } from '@cloudscape-design/components/app-layout';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+
+import { Breadcrumbs, Notifications } from '../commons';
+import { CustomAppLayout } from '../commons/common-components';
+import { WeatherContent } from './content';
+
+export function App() {
+  const appLayout = useRef<AppLayoutProps.Ref>(null);
+  const [toolsOpen, setToolsOpen] = useState(false);
+
+  return (
+    <CustomAppLayout
+      ref={appLayout}
+      content={
+        <SpaceBetween size="m">
+          <WeatherContent />
+        </SpaceBetween>
+      }
+      breadcrumbs={<Breadcrumbs items={[{ text: 'Weather Dashboard', href: '#/' }]} />}
+      toolsHide
+      navigationHide
+      toolsOpen={toolsOpen}
+      onToolsChange={({ detail }) => setToolsOpen(detail.open)}
+      notifications={<Notifications />}
+    />
+  );
+}

--- a/src/pages/weather-dashboard/content.tsx
+++ b/src/pages/weather-dashboard/content.tsx
@@ -192,7 +192,7 @@ export function WeatherContent() {
       </Header>
 
       <Container header={<Header variant="h2">Search location</Header>}>
-        <Grid gridDefinition={[{ colspan: { default: 12, m: 6, l: 4 } }, { colspan: { default: 12, m: 3, l: 2 } }, { colspan: { default: 12, m: 3, l: 2 } }] }>
+        <Grid gridDefinition={[{ colspan: { default: 12, m: 6, l: 4 } }, { colspan: { default: 12, m: 3, l: 2 } }, { colspan: { default: 12, m: 3, l: 2 } }]}>
           <FormField label="City or place name">
             <Input
               value={query}
@@ -230,9 +230,7 @@ export function WeatherContent() {
         )}
       </Container>
 
-      <Container
-        header={<Header variant="h2">Current conditions</Header>}
-      >
+      <Container header={<Header variant="h2">Current conditions</Header>}>
         {summary ? (
           <Grid gridDefinition={[{ colspan: { default: 12, s: 6, l: 3 } }, { colspan: { default: 12, s: 6, l: 3 } }, { colspan: { default: 12, s: 6, l: 3 } }, { colspan: { default: 12, s: 6, l: 3 } }]}>
             <Box>
@@ -269,12 +267,12 @@ export function WeatherContent() {
           trackBy="date"
           items={dailyItems}
           loadingText="Loading forecast"
-          columnDefinitions=[
-            { id: 'date', header: 'Date', cell: item => new Date(item.date).toLocaleDateString() },
-            { id: 'min', header: 'Min (°C)', cell: item => `${item.min.toFixed(1)}` },
-            { id: 'max', header: 'Max (°C)', cell: item => `${item.max.toFixed(1)}` },
-            { id: 'precip', header: 'Precip (mm)', cell: item => (item.precip ?? 0).toFixed(1) },
-          ]
+          columnDefinitions={[
+            { id: 'date', header: 'Date', cell: (item: any) => new Date(item.date).toLocaleDateString() },
+            { id: 'min', header: 'Min (°C)', cell: (item: any) => `${item.min.toFixed(1)}` },
+            { id: 'max', header: 'Max (°C)', cell: (item: any) => `${item.max.toFixed(1)}` },
+            { id: 'precip', header: 'Precip (mm)', cell: (item: any) => (item.precip ?? 0).toFixed(1) },
+          ]}
           empty={<Box variant="p">Search and select a location, then load the forecast.</Box>}
           header={<Header counter={dailyItems.length ? `(${dailyItems.length})` : undefined}>Daily forecast</Header>}
         />

--- a/src/pages/weather-dashboard/content.tsx
+++ b/src/pages/weather-dashboard/content.tsx
@@ -126,7 +126,9 @@ export function WeatherContent() {
         longitude: r.longitude,
       }));
       setLocations(results);
-      if (results.length === 1) {
+      if (results.length === 0) {
+        setError('No locations found. Try a different search.');
+      } else if (results.length === 1) {
         const only = results[0];
         setSelected({ label: formatLocation(only), value: String(only.id) });
       }

--- a/src/pages/weather-dashboard/content.tsx
+++ b/src/pages/weather-dashboard/content.tsx
@@ -90,7 +90,7 @@ export function WeatherContent() {
         value: String(loc.id),
         description: `Lat ${loc.latitude.toFixed(2)}, Lon ${loc.longitude.toFixed(2)}`,
       })),
-    [locations]
+    [locations],
   );
 
   const selectedLocation = useMemo(() => {
@@ -112,7 +112,7 @@ export function WeatherContent() {
     setLoading(true);
     try {
       const url = `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(
-        trimmed
+        trimmed,
       )}&count=10&language=en&format=json`;
       const res = await fetch(url);
       if (!res.ok) throw new Error('Failed to fetch locations');
@@ -194,7 +194,13 @@ export function WeatherContent() {
       </Header>
 
       <Container header={<Header variant="h2">Search location</Header>}>
-        <Grid gridDefinition={[{ colspan: { default: 12, m: 6, l: 4 } }, { colspan: { default: 12, m: 3, l: 2 } }, { colspan: { default: 12, m: 3, l: 2 } }]}>
+        <Grid
+          gridDefinition={[
+            { colspan: { default: 12, m: 6, l: 4 } },
+            { colspan: { default: 12, m: 3, l: 2 } },
+            { colspan: { default: 12, m: 3, l: 2 } },
+          ]}
+        >
           <FormField label="City or place name">
             <Input
               value={query}
@@ -234,7 +240,14 @@ export function WeatherContent() {
 
       <Container header={<Header variant="h2">Current conditions</Header>}>
         {summary ? (
-          <Grid gridDefinition={[{ colspan: { default: 12, s: 6, l: 3 } }, { colspan: { default: 12, s: 6, l: 3 } }, { colspan: { default: 12, s: 6, l: 3 } }, { colspan: { default: 12, s: 6, l: 3 } }]}>
+          <Grid
+            gridDefinition={[
+              { colspan: { default: 12, s: 6, l: 3 } },
+              { colspan: { default: 12, s: 6, l: 3 } },
+              { colspan: { default: 12, s: 6, l: 3 } },
+              { colspan: { default: 12, s: 6, l: 3 } },
+            ]}
+          >
             <Box>
               <Box variant="awsui-key-label">Temperature</Box>
               <Box variant="p">{summary.temperature} °C</Box>
@@ -261,7 +274,10 @@ export function WeatherContent() {
         header={<Header variant="h2">7-day forecast</Header>}
         footer={
           <Box variant="p">
-            Data from <Link href="https://open-meteo.com/" external>Open-Meteo</Link>
+            Data from{' '}
+            <Link href="https://open-meteo.com/" external>
+              Open-Meteo
+            </Link>
           </Box>
         }
       >

--- a/src/pages/weather-dashboard/content.tsx
+++ b/src/pages/weather-dashboard/content.tsx
@@ -1,0 +1,284 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useCallback, useMemo, useState } from 'react';
+import Header from '@cloudscape-design/components/header';
+import Container from '@cloudscape-design/components/container';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Grid from '@cloudscape-design/components/grid';
+import Box from '@cloudscape-design/components/box';
+import FormField from '@cloudscape-design/components/form-field';
+import Input from '@cloudscape-design/components/input';
+import Button from '@cloudscape-design/components/button';
+import Select, { SelectProps } from '@cloudscape-design/components/select';
+import Table from '@cloudscape-design/components/table';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import Link from '@cloudscape-design/components/link';
+
+type GeoResult = {
+  id: number;
+  name: string;
+  country: string;
+  admin1?: string;
+  latitude: number;
+  longitude: number;
+};
+
+type ForecastResponse = {
+  daily?: {
+    time: string[];
+    temperature_2m_max: number[];
+    temperature_2m_min: number[];
+    precipitation_sum?: number[];
+  };
+  current_weather?: {
+    temperature: number;
+    windspeed: number;
+    winddirection: number;
+    weathercode: number;
+    time: string;
+  };
+  timezone?: string;
+};
+
+const weatherCodeMap: Record<number, string> = {
+  0: 'Clear sky',
+  1: 'Mainly clear',
+  2: 'Partly cloudy',
+  3: 'Overcast',
+  45: 'Fog',
+  48: 'Depositing rime fog',
+  51: 'Light drizzle',
+  53: 'Moderate drizzle',
+  55: 'Dense drizzle',
+  56: 'Light freezing drizzle',
+  57: 'Dense freezing drizzle',
+  61: 'Slight rain',
+  63: 'Moderate rain',
+  65: 'Heavy rain',
+  66: 'Light freezing rain',
+  67: 'Heavy freezing rain',
+  71: 'Slight snow fall',
+  73: 'Moderate snow fall',
+  75: 'Heavy snow fall',
+  77: 'Snow grains',
+  80: 'Slight rain showers',
+  81: 'Moderate rain showers',
+  82: 'Violent rain showers',
+  85: 'Slight snow showers',
+  86: 'Heavy snow showers',
+  95: 'Thunderstorm',
+  96: 'Thunderstorm with slight hail',
+  99: 'Thunderstorm with heavy hail',
+};
+
+function formatLocation(r: GeoResult) {
+  return [r.name, r.admin1, r.country].filter(Boolean).join(', ');
+}
+
+export function WeatherContent() {
+  const [query, setQuery] = useState('');
+  const [locations, setLocations] = useState<GeoResult[]>([]);
+  const [selected, setSelected] = useState<SelectProps.Option | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [forecast, setForecast] = useState<ForecastResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const options: SelectProps.Options = useMemo(
+    () =>
+      locations.map(loc => ({
+        label: formatLocation(loc),
+        value: String(loc.id),
+        description: `Lat ${loc.latitude.toFixed(2)}, Lon ${loc.longitude.toFixed(2)}`,
+      })),
+    [locations]
+  );
+
+  const selectedLocation = useMemo(() => {
+    if (!selected) return undefined;
+    const id = Number(selected.value);
+    return locations.find(l => l.id === id);
+  }, [selected, locations]);
+
+  const searchLocations = useCallback(async () => {
+    setError(null);
+    setForecast(null);
+    setLocations([]);
+    setSelected(null);
+    const trimmed = query.trim();
+    if (trimmed.length < 2) {
+      setError('Enter at least 2 characters to search.');
+      return;
+    }
+    setLoading(true);
+    try {
+      const url = `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(
+        trimmed
+      )}&count=10&language=en&format=json`;
+      const res = await fetch(url);
+      if (!res.ok) throw new Error('Failed to fetch locations');
+      const json = await res.json();
+      const results: GeoResult[] = (json.results || []).map((r: any) => ({
+        id: r.id,
+        name: r.name,
+        country: r.country,
+        admin1: r.admin1,
+        latitude: r.latitude,
+        longitude: r.longitude,
+      }));
+      setLocations(results);
+      if (results.length === 1) {
+        const only = results[0];
+        setSelected({ label: formatLocation(only), value: String(only.id) });
+      }
+    } catch (e: any) {
+      setError(e.message || 'Search failed');
+    } finally {
+      setLoading(false);
+    }
+  }, [query]);
+
+  const fetchForecast = useCallback(async () => {
+    if (!selectedLocation) return;
+    setError(null);
+    setLoading(true);
+    try {
+      const { latitude, longitude } = selectedLocation;
+      const params = new URLSearchParams({
+        latitude: String(latitude),
+        longitude: String(longitude),
+        timezone: 'auto',
+        daily: 'temperature_2m_max,temperature_2m_min,precipitation_sum',
+        current_weather: 'true',
+      });
+      const url = `https://api.open-meteo.com/v1/forecast?${params.toString()}`;
+      const res = await fetch(url);
+      if (!res.ok) throw new Error('Failed to fetch weather');
+      const data: ForecastResponse = await res.json();
+      setForecast(data);
+    } catch (e: any) {
+      setError(e.message || 'Weather request failed');
+    } finally {
+      setLoading(false);
+    }
+  }, [selectedLocation]);
+
+  const dailyItems = useMemo(() => {
+    if (!forecast?.daily) return [] as Array<{ date: string; min: number; max: number; precip: number | undefined }>;
+    const { time, temperature_2m_min, temperature_2m_max, precipitation_sum } = forecast.daily;
+    return time.map((t, i) => ({
+      date: t,
+      min: temperature_2m_min[i],
+      max: temperature_2m_max[i],
+      precip: precipitation_sum ? precipitation_sum[i] : undefined,
+    }));
+  }, [forecast]);
+
+  const summary = useMemo(() => {
+    const cw = forecast?.current_weather;
+    if (!cw) return null;
+    return {
+      temperature: cw.temperature,
+      windspeed: cw.windspeed,
+      code: cw.weathercode,
+      description: weatherCodeMap[cw.weathercode] ?? 'Unknown',
+      time: cw.time,
+    };
+  }, [forecast]);
+
+  return (
+    <SpaceBetween size="l">
+      <Header variant="h1" description="Real-time weather powered by Open-Meteo">
+        Weather Dashboard
+      </Header>
+
+      <Container header={<Header variant="h2">Search location</Header>}>
+        <Grid gridDefinition={[{ colspan: { default: 12, m: 6, l: 4 } }, { colspan: { default: 12, m: 3, l: 2 } }, { colspan: { default: 12, m: 3, l: 2 } }] }>
+          <FormField label="City or place name">
+            <Input
+              value={query}
+              onChange={({ detail }) => setQuery(detail.value)}
+              placeholder="e.g., Seattle, Berlin, Tokyo"
+              onKeyDown={e => {
+                if (e.detail.key === 'Enter') searchLocations();
+              }}
+            />
+          </FormField>
+          <FormField label="">
+            <Button variant="primary" onClick={searchLocations} loading={loading}>
+              Search
+            </Button>
+          </FormField>
+          <FormField label="Select a location" stretch>
+            <Select
+              selectedOption={selected ?? undefined}
+              onChange={({ detail }) => setSelected(detail.selectedOption)}
+              options={options as SelectProps.Options}
+              placeholder="Search to load locations"
+              disabled={options.length === 0}
+            />
+          </FormField>
+        </Grid>
+        <Box margin={{ top: 's' }}>
+          <Button onClick={fetchForecast} disabled={!selectedLocation} iconName="arrow-right">
+            Load forecast
+          </Button>
+        </Box>
+        {error && (
+          <Box margin={{ top: 'm' }}>
+            <StatusIndicator type="error">{error}</StatusIndicator>
+          </Box>
+        )}
+      </Container>
+
+      <Container
+        header={<Header variant="h2">Current conditions</Header>}
+      >
+        {summary ? (
+          <Grid gridDefinition={[{ colspan: { default: 12, s: 6, l: 3 } }, { colspan: { default: 12, s: 6, l: 3 } }, { colspan: { default: 12, s: 6, l: 3 } }, { colspan: { default: 12, s: 6, l: 3 } }]}>
+            <Box>
+              <Box variant="awsui-key-label">Temperature</Box>
+              <Box variant="p">{summary.temperature} °C</Box>
+            </Box>
+            <Box>
+              <Box variant="awsui-key-label">Condition</Box>
+              <Box variant="p">{summary.description}</Box>
+            </Box>
+            <Box>
+              <Box variant="awsui-key-label">Wind speed</Box>
+              <Box variant="p">{summary.windspeed} km/h</Box>
+            </Box>
+            <Box>
+              <Box variant="awsui-key-label">As of</Box>
+              <Box variant="p">{new Date(summary.time).toLocaleString()}</Box>
+            </Box>
+          </Grid>
+        ) : (
+          <StatusIndicator type="stopped">No data loaded</StatusIndicator>
+        )}
+      </Container>
+
+      <Container
+        header={<Header variant="h2">7-day forecast</Header>}
+        footer={
+          <Box variant="p">
+            Data from <Link href="https://open-meteo.com/" external>Open-Meteo</Link>
+          </Box>
+        }
+      >
+        <Table
+          trackBy="date"
+          items={dailyItems}
+          loadingText="Loading forecast"
+          columnDefinitions=[
+            { id: 'date', header: 'Date', cell: item => new Date(item.date).toLocaleDateString() },
+            { id: 'min', header: 'Min (°C)', cell: item => `${item.min.toFixed(1)}` },
+            { id: 'max', header: 'Max (°C)', cell: item => `${item.max.toFixed(1)}` },
+            { id: 'precip', header: 'Precip (mm)', cell: item => (item.precip ?? 0).toFixed(1) },
+          ]
+          empty={<Box variant="p">Search and select a location, then load the forecast.</Box>}
+          header={<Header counter={dailyItems.length ? `(${dailyItems.length})` : undefined}>Daily forecast</Header>}
+        />
+      </Container>
+    </SpaceBetween>
+  );
+}

--- a/src/pages/weather-dashboard/index.tsx
+++ b/src/pages/weather-dashboard/index.tsx
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import { App } from './app';
+
+import '../../styles/base.scss';
+
+export default function WeatherDashboardDemo() {
+  return <App />;
+}


### PR DESCRIPTION
## Purpose

The user requested the addition of a new weather dashboard that integrates with the Open-Meteo forecast API to display real-time weather data. Additionally, a network administration dashboard was created to provide network traffic monitoring and device management capabilities.

## Code changes

- **Added weather dashboard** (`/weather-dashboard`):
  - Created complete weather dashboard with location search using Open-Meteo geocoding API
  - Implemented current weather conditions display with temperature, wind speed, and weather descriptions
  - Added 7-day forecast table with min/max temperatures and precipitation data
  - Integrated responsive design with proper form controls and error handling

- **Added network dashboard** (`/network-dashboard`):
  - Created network administration dashboard with traffic monitoring charts
  - Implemented device management table with status indicators (Online/Warning/Offline)
  - Added area charts for network traffic visualization and bar charts for credit usage
  - Included device filtering, pagination, and status management features

- **Updated main index** to register both new dashboard routes in the demos list under the "Dashboards" category

Both dashboards follow the existing application structure with proper TypeScript types, responsive layouts, and CloudScape Design System components.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 19`

🔗 [Edit in Builder.io](https://builder.io/app/projects/82a0d72280b64a4e9c841241494d5ab4/curry-landing)

👀 [Preview Link](https://82a0d72280b64a4e9c841241494d5ab4-curry-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>82a0d72280b64a4e9c841241494d5ab4</projectId>-->
<!--<branchName>curry-landing</branchName>-->