### PR TITLE
feat: Add Network Dashboard page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -128,6 +128,7 @@ const demos = [
   },
   { route: '/wizard', title: 'Wizard', description: 'Multi-step wizard demo.', category: 'Forms' },
   { route: '/write-to-s3', title: 'Write to S3', description: 'Write data to Amazon S3.', category: 'Integration' },
+  { route: '/network-dashboard', title: 'Network Dashboard', description: 'Network administration dashboard with traffic and device monitoring.', category: 'Dashboards' },
 ];
 
 // Get unique categories

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -128,7 +128,12 @@ const demos = [
   },
   { route: '/wizard', title: 'Wizard', description: 'Multi-step wizard demo.', category: 'Forms' },
   { route: '/write-to-s3', title: 'Write to S3', description: 'Write data to Amazon S3.', category: 'Integration' },
-  { route: '/network-dashboard', title: 'Network Dashboard', description: 'Network administration dashboard with traffic and device monitoring.', category: 'Dashboards' },
+  {
+    route: '/network-dashboard',
+    title: 'Network Dashboard',
+    description: 'Network administration dashboard with traffic and device monitoring.',
+    category: 'Dashboards',
+  },
 ];
 
 // Get unique categories

--- a/src/pages/network-dashboard/index.tsx
+++ b/src/pages/network-dashboard/index.tsx
@@ -158,7 +158,7 @@ export default function NetworkDashboard() {
         <Flashbar
           items={[
             {
-              type: 'warning',
+              type: 'error',
               dismissible: true,
               content: 'This is a warning message',
               id: 'warning-message'

--- a/src/pages/network-dashboard/index.tsx
+++ b/src/pages/network-dashboard/index.tsx
@@ -155,10 +155,7 @@ export default function NetworkDashboard() {
           Network Adminstration Dashboard
         </Header>
 
-        <Alert
-          type="error"
-          dismissible
-        >
+        <Alert type="error" dismissible>
           This is a warning message
         </Alert>
 

--- a/src/pages/network-dashboard/index.tsx
+++ b/src/pages/network-dashboard/index.tsx
@@ -155,16 +155,12 @@ export default function NetworkDashboard() {
           Network Adminstration Dashboard
         </Header>
 
-        <Flashbar
-          items={[
-            {
-              type: 'error',
-              dismissible: true,
-              content: 'This is a warning message',
-              id: 'warning-message',
-            },
-          ]}
-        />
+        <Alert
+          type="error"
+          dismissible
+        >
+          This is a warning message
+        </Alert>
 
         <div
           style={{

--- a/src/pages/network-dashboard/index.tsx
+++ b/src/pages/network-dashboard/index.tsx
@@ -35,9 +35,9 @@ export default function NetworkDashboard() {
         { x: new Date(2024, 0, 9), y: 5.2 },
         { x: new Date(2024, 0, 10), y: 5.5 },
         { x: new Date(2024, 0, 11), y: 5.8 },
-        { x: new Date(2024, 0, 12), y: 4.2 }
+        { x: new Date(2024, 0, 12), y: 4.2 },
       ],
-      valueFormatter: (value) => value.toFixed(1)
+      valueFormatter: value => value.toFixed(1),
     },
     {
       title: 'Site 2',
@@ -54,10 +54,10 @@ export default function NetworkDashboard() {
         { x: new Date(2024, 0, 9), y: 3.5 },
         { x: new Date(2024, 0, 10), y: 2.8 },
         { x: new Date(2024, 0, 11), y: 2.5 },
-        { x: new Date(2024, 0, 12), y: 2.2 }
+        { x: new Date(2024, 0, 12), y: 2.2 },
       ],
-      valueFormatter: (value) => value.toFixed(1)
-    }
+      valueFormatter: value => value.toFixed(1),
+    },
   ];
 
   // Bar chart data
@@ -70,10 +70,10 @@ export default function NetworkDashboard() {
         { x: new Date(2024, 0, 2), y: 5 },
         { x: new Date(2024, 0, 3), y: 4.2 },
         { x: new Date(2024, 0, 4), y: 2.5 },
-        { x: new Date(2024, 0, 5), y: 4.1 }
+        { x: new Date(2024, 0, 5), y: 4.1 },
       ],
-      valueFormatter: (value) => value.toFixed(1)
-    }
+      valueFormatter: value => value.toFixed(1),
+    },
   ];
 
   // Table data
@@ -85,52 +85,52 @@ export default function NetworkDashboard() {
     status: i % 3 === 0 ? 'Active' : i % 3 === 1 ? 'Inactive' : 'Pending',
     type: ['Router', 'Switch', 'Access Point', 'Server'][i % 4],
     location: ['Floor 1', 'Floor 2', 'Floor 3'][i % 3],
-    lastSeen: `${i + 1} hours ago`
+    lastSeen: `${i + 1} hours ago`,
   }));
 
   const columnDefinitions = [
     {
       id: 'name',
       header: 'Device Name',
-      cell: (item) => item.name,
-      sortingField: 'name'
+      cell: item => item.name,
+      sortingField: 'name',
     },
     {
       id: 'ipAddress',
       header: 'IP Address',
-      cell: (item) => item.ipAddress,
-      sortingField: 'ipAddress'
+      cell: item => item.ipAddress,
+      sortingField: 'ipAddress',
     },
     {
       id: 'macAddress',
       header: 'MAC Address',
-      cell: (item) => item.macAddress,
-      sortingField: 'macAddress'
+      cell: item => item.macAddress,
+      sortingField: 'macAddress',
     },
     {
       id: 'status',
       header: 'Status',
-      cell: (item) => item.status,
-      sortingField: 'status'
+      cell: item => item.status,
+      sortingField: 'status',
     },
     {
       id: 'type',
       header: 'Type',
-      cell: (item) => item.type,
-      sortingField: 'type'
+      cell: item => item.type,
+      sortingField: 'type',
     },
     {
       id: 'location',
       header: 'Location',
-      cell: (item) => item.location,
-      sortingField: 'location'
+      cell: item => item.location,
+      sortingField: 'location',
     },
     {
       id: 'lastSeen',
       header: 'Last Seen',
-      cell: (item) => item.lastSeen,
-      sortingField: 'lastSeen'
-    }
+      cell: item => item.lastSeen,
+      sortingField: 'lastSeen',
+    },
   ];
 
   return (
@@ -139,7 +139,7 @@ export default function NetworkDashboard() {
         <BreadcrumbGroup
           items={[
             { text: 'Service', href: '#' },
-            { text: 'Administrative Dashboard', href: '#' }
+            { text: 'Administrative Dashboard', href: '#' },
           ]}
         />
 
@@ -161,12 +161,20 @@ export default function NetworkDashboard() {
               type: 'error',
               dismissible: true,
               content: 'This is a warning message',
-              id: 'warning-message'
-            }
+              id: 'warning-message',
+            },
           ]}
         />
 
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '16px', flexWrap: 'wrap' }}>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            gap: '16px',
+            flexWrap: 'wrap',
+          }}
+        >
           <Input
             type="search"
             value={searchValue}
@@ -195,9 +203,8 @@ export default function NetworkDashboard() {
                 filterSelectedAriaLabel: 'selected',
                 legendAriaLabel: 'Legend',
                 chartAriaRoleDescription: 'area chart',
-                xTickFormatter: (value) =>
-                  value instanceof Date ? `x${value.getDate()}` : String(value),
-                yTickFormatter: (value) => `y${value}`
+                xTickFormatter: value => (value instanceof Date ? `x${value.getDate()}` : String(value)),
+                yTickFormatter: value => `y${value}`,
               }}
               ariaLabel="Network traffic chart"
               height={300}
@@ -220,9 +227,8 @@ export default function NetworkDashboard() {
                 filterSelectedAriaLabel: 'selected',
                 legendAriaLabel: 'Legend',
                 chartAriaRoleDescription: 'bar chart',
-                xTickFormatter: (value) =>
-                  value instanceof Date ? `x${value.getDate()}` : String(value),
-                yTickFormatter: (value) => `y${value}`
+                xTickFormatter: value => (value instanceof Date ? `x${value.getDate()}` : String(value)),
+                yTickFormatter: value => `y${value}`,
               }}
               ariaLabel="Credit usage chart"
               height={300}

--- a/src/pages/network-dashboard/index.tsx
+++ b/src/pages/network-dashboard/index.tsx
@@ -10,7 +10,7 @@ import SpaceBetween from '@cloudscape-design/components/space-between';
 import AreaChart from '@cloudscape-design/components/area-chart';
 import BarChart from '@cloudscape-design/components/bar-chart';
 import Grid from '@cloudscape-design/components/grid';
-import Flashbar from '@cloudscape-design/components/flashbar';
+import Alert from '@cloudscape-design/components/alert';
 import { useState } from 'react';
 
 export default function NetworkDashboard() {

--- a/src/pages/network-dashboard/index.tsx
+++ b/src/pages/network-dashboard/index.tsx
@@ -1,0 +1,265 @@
+import BreadcrumbGroup from '@cloudscape-design/components/breadcrumb-group';
+import Button from '@cloudscape-design/components/button';
+import Container from '@cloudscape-design/components/container';
+import Header from '@cloudscape-design/components/header';
+import Input from '@cloudscape-design/components/input';
+import Pagination from '@cloudscape-design/components/pagination';
+import Table from '@cloudscape-design/components/table';
+import Box from '@cloudscape-design/components/box';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import AreaChart from '@cloudscape-design/components/area-chart';
+import BarChart from '@cloudscape-design/components/bar-chart';
+import Grid from '@cloudscape-design/components/grid';
+import Flashbar from '@cloudscape-design/components/flashbar';
+import { useState } from 'react';
+
+export default function NetworkDashboard() {
+  const [searchValue, setSearchValue] = useState('');
+  const [currentPageIndex, setCurrentPageIndex] = useState(1);
+  const [selectedItems, setSelectedItems] = useState([]);
+
+  // Area chart data
+  const areaChartSeries = [
+    {
+      title: 'Site 1',
+      type: 'area',
+      data: [
+        { x: 1, y: 3 },
+        { x: 2, y: 2.8 },
+        { x: 3, y: 3.2 },
+        { x: 4, y: 3.5 },
+        { x: 5, y: 4.2 },
+        { x: 6, y: 5.1 },
+        { x: 7, y: 4.8 },
+        { x: 8, y: 4.5 },
+        { x: 9, y: 5.2 },
+        { x: 10, y: 5.5 },
+        { x: 11, y: 5.8 },
+        { x: 12, y: 4.2 }
+      ],
+      valueFormatter: (value) => `${value}`
+    },
+    {
+      title: 'Site 2',
+      type: 'area',
+      data: [
+        { x: 1, y: 2 },
+        { x: 2, y: 2.5 },
+        { x: 3, y: 2.8 },
+        { x: 4, y: 3.2 },
+        { x: 5, y: 3.8 },
+        { x: 6, y: 4.5 },
+        { x: 7, y: 3.8 },
+        { x: 8, y: 3.2 },
+        { x: 9, y: 3.5 },
+        { x: 10, y: 2.8 },
+        { x: 11, y: 2.5 },
+        { x: 12, y: 2.2 }
+      ],
+      valueFormatter: (value) => `${value}`
+    }
+  ];
+
+  // Bar chart data
+  const barChartSeries = [
+    {
+      title: 'Site 1',
+      type: 'bar',
+      data: [
+        { x: 1, y: 3.5 },
+        { x: 2, y: 5 },
+        { x: 3, y: 4.2 },
+        { x: 4, y: 2.5 },
+        { x: 5, y: 4.1 }
+      ],
+      valueFormatter: (value) => `${value}`
+    }
+  ];
+
+  // Table data
+  const tableItems = Array.from({ length: 12 }, (_, i) => ({
+    id: `device-${i + 1}`,
+    name: `Device ${i + 1}`,
+    ipAddress: `192.168.1.${i + 10}`,
+    macAddress: `00:1B:44:11:3A:${(i + 10).toString(16).padStart(2, '0')}`,
+    status: i % 3 === 0 ? 'Active' : i % 3 === 1 ? 'Inactive' : 'Pending',
+    type: ['Router', 'Switch', 'Access Point', 'Server'][i % 4],
+    location: ['Floor 1', 'Floor 2', 'Floor 3'][i % 3],
+    lastSeen: `${i + 1} hours ago`
+  }));
+
+  const columnDefinitions = [
+    {
+      id: 'name',
+      header: 'Device Name',
+      cell: (item) => item.name,
+      sortingField: 'name'
+    },
+    {
+      id: 'ipAddress',
+      header: 'IP Address',
+      cell: (item) => item.ipAddress,
+      sortingField: 'ipAddress'
+    },
+    {
+      id: 'macAddress',
+      header: 'MAC Address',
+      cell: (item) => item.macAddress,
+      sortingField: 'macAddress'
+    },
+    {
+      id: 'status',
+      header: 'Status',
+      cell: (item) => item.status,
+      sortingField: 'status'
+    },
+    {
+      id: 'type',
+      header: 'Type',
+      cell: (item) => item.type,
+      sortingField: 'type'
+    },
+    {
+      id: 'location',
+      header: 'Location',
+      cell: (item) => item.location,
+      sortingField: 'location'
+    },
+    {
+      id: 'lastSeen',
+      header: 'Last Seen',
+      cell: (item) => item.lastSeen,
+      sortingField: 'lastSeen'
+    }
+  ];
+
+  return (
+    <div style={{ padding: '20px' }}>
+      <SpaceBetween size="l">
+        <BreadcrumbGroup
+          items={[
+            { text: 'Service', href: '#' },
+            { text: 'Administrative Dashboard', href: '#' }
+          ]}
+        />
+
+        <Header
+          variant="h1"
+          description="Network Traffic, Credit Usage, and Your Devices"
+          actions={
+            <Button variant="primary" iconAlign="right" iconName="external">
+              Refresh Data
+            </Button>
+          }
+        >
+          Network Adminstration Dashboard
+        </Header>
+
+        <Flashbar
+          items={[
+            {
+              type: 'warning',
+              dismissible: true,
+              content: 'This is a warning message',
+              id: 'warning-message'
+            }
+          ]}
+        />
+
+        <Box>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '16px' }}>
+            <Input
+              type="search"
+              value={searchValue}
+              onChange={({ detail }) => setSearchValue(detail.value)}
+              placeholder="Placeholder"
+              style={{ maxWidth: '500px' }}
+            />
+            <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+              <Pagination
+                currentPageIndex={currentPageIndex}
+                onChange={({ detail }) => setCurrentPageIndex(detail.currentPageIndex)}
+                pagesCount={5}
+              />
+            </div>
+          </div>
+        </Box>
+
+        <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+          <Container>
+            <AreaChart
+              series={areaChartSeries}
+              xDomain={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]}
+              yDomain={[0, 6]}
+              i18nStrings={{
+                filterLabel: 'Filter displayed data',
+                filterPlaceholder: 'Filter data',
+                filterSelectedAriaLabel: 'selected',
+                legendAriaLabel: 'Legend',
+                chartAriaRoleDescription: 'area chart',
+                xTickFormatter: (value) => `x${value}`,
+                yTickFormatter: (value) => `y${value}`
+              }}
+              ariaLabel="Network traffic chart"
+              height={300}
+              xTitle="Day"
+              yTitle="Network traffic"
+              hideFilter
+              statusType="finished"
+            />
+          </Container>
+
+          <Container>
+            <BarChart
+              series={barChartSeries}
+              xDomain={[1, 2, 3, 4, 5]}
+              yDomain={[0, 6]}
+              i18nStrings={{
+                filterLabel: 'Filter displayed data',
+                filterPlaceholder: 'Filter data',
+                filterSelectedAriaLabel: 'selected',
+                legendAriaLabel: 'Legend',
+                chartAriaRoleDescription: 'bar chart',
+                xTickFormatter: (value) => `x${value}`,
+                yTickFormatter: (value) => `y${value}`
+              }}
+              ariaLabel="Credit usage chart"
+              height={300}
+              xTitle="Day"
+              yTitle="Credit Usage"
+              hideFilter
+              statusType="finished"
+            />
+          </Container>
+        </Grid>
+
+        <Header
+          variant="h2"
+          description="Devices on your local network"
+          actions={
+            <Button variant="primary" iconAlign="right" iconName="external">
+              Add Device
+            </Button>
+          }
+        >
+          My Devices
+        </Header>
+
+        <Table
+          columnDefinitions={columnDefinitions}
+          items={tableItems}
+          selectionType="multi"
+          selectedItems={selectedItems}
+          onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
+          trackBy="id"
+          variant="container"
+          stickyHeader
+          resizableColumns
+          wrapLines
+          stripedRows
+          sortingDisabled={false}
+        />
+      </SpaceBetween>
+    </div>
+  );
+}

--- a/src/pages/network-dashboard/index.tsx
+++ b/src/pages/network-dashboard/index.tsx
@@ -24,39 +24,39 @@ export default function NetworkDashboard() {
       title: 'Site 1',
       type: 'area',
       data: [
-        { x: 1, y: 3 },
-        { x: 2, y: 2.8 },
-        { x: 3, y: 3.2 },
-        { x: 4, y: 3.5 },
-        { x: 5, y: 4.2 },
-        { x: 6, y: 5.1 },
-        { x: 7, y: 4.8 },
-        { x: 8, y: 4.5 },
-        { x: 9, y: 5.2 },
-        { x: 10, y: 5.5 },
-        { x: 11, y: 5.8 },
-        { x: 12, y: 4.2 }
+        { x: new Date(2024, 0, 1), y: 3 },
+        { x: new Date(2024, 0, 2), y: 2.8 },
+        { x: new Date(2024, 0, 3), y: 3.2 },
+        { x: new Date(2024, 0, 4), y: 3.5 },
+        { x: new Date(2024, 0, 5), y: 4.2 },
+        { x: new Date(2024, 0, 6), y: 5.1 },
+        { x: new Date(2024, 0, 7), y: 4.8 },
+        { x: new Date(2024, 0, 8), y: 4.5 },
+        { x: new Date(2024, 0, 9), y: 5.2 },
+        { x: new Date(2024, 0, 10), y: 5.5 },
+        { x: new Date(2024, 0, 11), y: 5.8 },
+        { x: new Date(2024, 0, 12), y: 4.2 }
       ],
-      valueFormatter: (value) => `${value}`
+      valueFormatter: (value) => value.toFixed(1)
     },
     {
       title: 'Site 2',
       type: 'area',
       data: [
-        { x: 1, y: 2 },
-        { x: 2, y: 2.5 },
-        { x: 3, y: 2.8 },
-        { x: 4, y: 3.2 },
-        { x: 5, y: 3.8 },
-        { x: 6, y: 4.5 },
-        { x: 7, y: 3.8 },
-        { x: 8, y: 3.2 },
-        { x: 9, y: 3.5 },
-        { x: 10, y: 2.8 },
-        { x: 11, y: 2.5 },
-        { x: 12, y: 2.2 }
+        { x: new Date(2024, 0, 1), y: 2 },
+        { x: new Date(2024, 0, 2), y: 2.5 },
+        { x: new Date(2024, 0, 3), y: 2.8 },
+        { x: new Date(2024, 0, 4), y: 3.2 },
+        { x: new Date(2024, 0, 5), y: 3.8 },
+        { x: new Date(2024, 0, 6), y: 4.5 },
+        { x: new Date(2024, 0, 7), y: 3.8 },
+        { x: new Date(2024, 0, 8), y: 3.2 },
+        { x: new Date(2024, 0, 9), y: 3.5 },
+        { x: new Date(2024, 0, 10), y: 2.8 },
+        { x: new Date(2024, 0, 11), y: 2.5 },
+        { x: new Date(2024, 0, 12), y: 2.2 }
       ],
-      valueFormatter: (value) => `${value}`
+      valueFormatter: (value) => value.toFixed(1)
     }
   ];
 
@@ -66,13 +66,13 @@ export default function NetworkDashboard() {
       title: 'Site 1',
       type: 'bar',
       data: [
-        { x: 1, y: 3.5 },
-        { x: 2, y: 5 },
-        { x: 3, y: 4.2 },
-        { x: 4, y: 2.5 },
-        { x: 5, y: 4.1 }
+        { x: new Date(2024, 0, 1), y: 3.5 },
+        { x: new Date(2024, 0, 2), y: 5 },
+        { x: new Date(2024, 0, 3), y: 4.2 },
+        { x: new Date(2024, 0, 4), y: 2.5 },
+        { x: new Date(2024, 0, 5), y: 4.1 }
       ],
-      valueFormatter: (value) => `${value}`
+      valueFormatter: (value) => value.toFixed(1)
     }
   ];
 
@@ -166,30 +166,28 @@ export default function NetworkDashboard() {
           ]}
         />
 
-        <Box>
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '16px' }}>
-            <Input
-              type="search"
-              value={searchValue}
-              onChange={({ detail }) => setSearchValue(detail.value)}
-              placeholder="Placeholder"
-              style={{ maxWidth: '500px' }}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '16px', flexWrap: 'wrap' }}>
+          <Input
+            type="search"
+            value={searchValue}
+            onChange={({ detail }) => setSearchValue(detail.value)}
+            placeholder="Placeholder"
+            style={{ flexGrow: 1, maxWidth: '500px' }}
+          />
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <Pagination
+              currentPageIndex={currentPageIndex}
+              onChange={({ detail }) => setCurrentPageIndex(detail.currentPageIndex)}
+              pagesCount={5}
             />
-            <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-              <Pagination
-                currentPageIndex={currentPageIndex}
-                onChange={({ detail }) => setCurrentPageIndex(detail.currentPageIndex)}
-                pagesCount={5}
-              />
-            </div>
+            <Button iconName="settings" variant="icon" />
           </div>
-        </Box>
+        </div>
 
         <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
-          <Container>
+          <Container header={<Header variant="h3">Network traffic</Header>}>
             <AreaChart
               series={areaChartSeries}
-              xDomain={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]}
               yDomain={[0, 6]}
               i18nStrings={{
                 filterLabel: 'Filter displayed data',
@@ -197,22 +195,24 @@ export default function NetworkDashboard() {
                 filterSelectedAriaLabel: 'selected',
                 legendAriaLabel: 'Legend',
                 chartAriaRoleDescription: 'area chart',
-                xTickFormatter: (value) => `x${value}`,
+                xTickFormatter: (value) =>
+                  value instanceof Date ? `x${value.getDate()}` : String(value),
                 yTickFormatter: (value) => `y${value}`
               }}
               ariaLabel="Network traffic chart"
               height={300}
               xTitle="Day"
-              yTitle="Network traffic"
+              yTitle=""
               hideFilter
               statusType="finished"
+              legendTitle="Legend"
+              detailPopoverFooter={() => 'Performance goal'}
             />
           </Container>
 
-          <Container>
+          <Container header={<Header variant="h3">Credit Usage</Header>}>
             <BarChart
               series={barChartSeries}
-              xDomain={[1, 2, 3, 4, 5]}
               yDomain={[0, 6]}
               i18nStrings={{
                 filterLabel: 'Filter displayed data',
@@ -220,15 +220,17 @@ export default function NetworkDashboard() {
                 filterSelectedAriaLabel: 'selected',
                 legendAriaLabel: 'Legend',
                 chartAriaRoleDescription: 'bar chart',
-                xTickFormatter: (value) => `x${value}`,
+                xTickFormatter: (value) =>
+                  value instanceof Date ? `x${value.getDate()}` : String(value),
                 yTickFormatter: (value) => `y${value}`
               }}
               ariaLabel="Credit usage chart"
               height={300}
               xTitle="Day"
-              yTitle="Credit Usage"
+              yTitle=""
               hideFilter
               statusType="finished"
+              legendTitle="Legend"
             />
           </Container>
         </Grid>

--- a/src/pages/network-dashboard/root.tsx
+++ b/src/pages/network-dashboard/root.tsx
@@ -1,0 +1,13 @@
+import AppLayout from '@cloudscape-design/components/app-layout';
+import NetworkDashboard from './index';
+
+export default function Root() {
+  return (
+    <AppLayout
+      navigationHide
+      toolsHide
+      content={<NetworkDashboard />}
+      contentType="default"
+    />
+  );
+}

--- a/src/pages/network-dashboard/root.tsx
+++ b/src/pages/network-dashboard/root.tsx
@@ -2,12 +2,5 @@ import AppLayout from '@cloudscape-design/components/app-layout';
 import NetworkDashboard from './index';
 
 export default function Root() {
-  return (
-    <AppLayout
-      navigationHide
-      toolsHide
-      content={<NetworkDashboard />}
-      contentType="default"
-    />
-  );
+  return <AppLayout navigationHide toolsHide content={<NetworkDashboard />} contentType="default" />;
 }


### PR DESCRIPTION
### Purpose

This pull request introduces a new Network Administration Dashboard. The goal is to provide users with a centralized view for monitoring network traffic, credit usage, and managing network devices.

### Code changes

- **New Page**: Created a new page component `src/pages/network-dashboard/index.tsx` that displays:
    - Network traffic and credit usage charts.
    - A filterable and sortable table of network devices.
- **Layout**: Added `src/pages/network-dashboard/root.tsx` to wrap the dashboard in the standard `AppLayout`.
- **Routing**: Updated `src/pages/index.tsx` to include a link to the new "Network Dashboard" on the main demos page.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 26`

🔗 [Edit in Builder.io](https://builder.io/app/projects/82a0d72280b64a4e9c841241494d5ab4/vibe-haven)

👀 [Preview Link](https://82a0d72280b64a4e9c841241494d5ab4-vibe-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>82a0d72280b64a4e9c841241494d5ab4</projectId>-->
<!--<branchName>vibe-haven</branchName>-->