### PR TITLE
feat: Add weather and network dashboard demos

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -128,8 +128,18 @@ const demos = [
   },
   { route: '/wizard', title: 'Wizard', description: 'Multi-step wizard demo.', category: 'Forms' },
   { route: '/write-to-s3', title: 'Write to S3', description: 'Write data to Amazon S3.', category: 'Integration' },
-  { route: '/weather-dashboard', title: 'Weather Dashboard', description: 'Real-time weather forecast using open-meteo API.', category: 'Dashboards' },
-  { route: '/network-dashboard', title: 'Network Administration Dashboard', description: 'Network monitoring with traffic charts and device management.', category: 'Dashboards' },
+  {
+    route: '/weather-dashboard',
+    title: 'Weather Dashboard',
+    description: 'Real-time weather forecast using open-meteo API.',
+    category: 'Dashboards',
+  },
+  {
+    route: '/network-dashboard',
+    title: 'Network Administration Dashboard',
+    description: 'Network monitoring with traffic charts and device management.',
+    category: 'Dashboards',
+  },
 ];
 
 // Get unique categories

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -128,6 +128,7 @@ const demos = [
   },
   { route: '/wizard', title: 'Wizard', description: 'Multi-step wizard demo.', category: 'Forms' },
   { route: '/write-to-s3', title: 'Write to S3', description: 'Write data to Amazon S3.', category: 'Integration' },
+  { route: '/weather-dashboard', title: 'Weather Dashboard', description: 'Real-time weather forecast using open-meteo API.', category: 'Dashboards' },
 ];
 
 // Get unique categories

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -129,6 +129,7 @@ const demos = [
   { route: '/wizard', title: 'Wizard', description: 'Multi-step wizard demo.', category: 'Forms' },
   { route: '/write-to-s3', title: 'Write to S3', description: 'Write data to Amazon S3.', category: 'Integration' },
   { route: '/weather-dashboard', title: 'Weather Dashboard', description: 'Real-time weather forecast using open-meteo API.', category: 'Dashboards' },
+  { route: '/network-dashboard', title: 'Network Administration Dashboard', description: 'Network monitoring with traffic charts and device management.', category: 'Dashboards' },
 ];
 
 // Get unique categories

--- a/src/pages/network-dashboard/app.tsx
+++ b/src/pages/network-dashboard/app.tsx
@@ -1,0 +1,438 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React, { useState } from 'react';
+import AppLayout from '@cloudscape-design/components/app-layout';
+import BreadcrumbGroup from '@cloudscape-design/components/breadcrumb-group';
+import Button from '@cloudscape-design/components/button';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Grid from '@cloudscape-design/components/grid';
+import Container from '@cloudscape-design/components/container';
+import AreaChart from '@cloudscape-design/components/area-chart';
+import BarChart from '@cloudscape-design/components/bar-chart';
+import Table from '@cloudscape-design/components/table';
+import Box from '@cloudscape-design/components/box';
+import TextFilter from '@cloudscape-design/components/text-filter';
+import Pagination from '@cloudscape-design/components/pagination';
+import Flashbar from '@cloudscape-design/components/flashbar';
+import ContentLayout from '@cloudscape-design/components/content-layout';
+
+interface DeviceItem {
+  id: string;
+  name: string;
+  type: string;
+  status: string;
+  ipAddress: string;
+  macAddress: string;
+  lastSeen: string;
+  bandwidth: string;
+}
+
+const networkTrafficData = [
+  { x: 'x1', y: 2.5 },
+  { x: 'x2', y: 3.2 },
+  { x: 'x3', y: 3.8 },
+  { x: 'x4', y: 4.1 },
+  { x: 'x5', y: 4.5 },
+  { x: 'x6', y: 5.2 },
+  { x: 'x7', y: 4.8 },
+  { x: 'x8', y: 4.3 },
+  { x: 'x9', y: 3.9 },
+  { x: 'x10', y: 3.5 },
+  { x: 'x11', y: 3.2 },
+  { x: 'x12', y: 2.8 },
+];
+
+const networkTrafficData2 = [
+  { x: 'x1', y: 1.8 },
+  { x: 'x2', y: 2.3 },
+  { x: 'x3', y: 2.1 },
+  { x: 'x4', y: 2.5 },
+  { x: 'x5', y: 2.2 },
+  { x: 'x6', y: 3.1 },
+  { x: 'x7', y: 2.9 },
+  { x: 'x8', y: 2.4 },
+  { x: 'x9', y: 1.5 },
+  { x: 'x10', y: 1.2 },
+  { x: 'x11', y: 1.8 },
+  { x: 'x12', y: 1.5 },
+];
+
+const creditUsageData = [
+  { x: 'x1', y: 3.2 },
+  { x: 'x2', y: 4.5 },
+  { x: 'x3', y: 3.8 },
+  { x: 'x4', y: 2.1 },
+  { x: 'x5', y: 3.7 },
+];
+
+const allDevices: DeviceItem[] = [
+  {
+    id: '1',
+    name: 'Server-01',
+    type: 'Server',
+    status: 'Active',
+    ipAddress: '192.168.1.10',
+    macAddress: '00:1B:44:11:3A:B7',
+    lastSeen: '2 minutes ago',
+    bandwidth: '125 Mbps',
+  },
+  {
+    id: '2',
+    name: 'Router-Main',
+    type: 'Router',
+    status: 'Active',
+    ipAddress: '192.168.1.1',
+    macAddress: '00:1B:44:11:3A:B8',
+    lastSeen: '1 minute ago',
+    bandwidth: '890 Mbps',
+  },
+  {
+    id: '3',
+    name: 'Switch-Floor1',
+    type: 'Switch',
+    status: 'Active',
+    ipAddress: '192.168.1.20',
+    macAddress: '00:1B:44:11:3A:B9',
+    lastSeen: '5 minutes ago',
+    bandwidth: '450 Mbps',
+  },
+  {
+    id: '4',
+    name: 'AP-Office-01',
+    type: 'Access Point',
+    status: 'Active',
+    ipAddress: '192.168.1.50',
+    macAddress: '00:1B:44:11:3A:C0',
+    lastSeen: '3 minutes ago',
+    bandwidth: '220 Mbps',
+  },
+  {
+    id: '5',
+    name: 'Firewall-01',
+    type: 'Firewall',
+    status: 'Active',
+    ipAddress: '192.168.1.2',
+    macAddress: '00:1B:44:11:3A:C1',
+    lastSeen: '1 minute ago',
+    bandwidth: '780 Mbps',
+  },
+  {
+    id: '6',
+    name: 'Server-02',
+    type: 'Server',
+    status: 'Inactive',
+    ipAddress: '192.168.1.11',
+    macAddress: '00:1B:44:11:3A:C2',
+    lastSeen: '2 hours ago',
+    bandwidth: '0 Mbps',
+  },
+  {
+    id: '7',
+    name: 'Switch-Floor2',
+    type: 'Switch',
+    status: 'Active',
+    ipAddress: '192.168.1.21',
+    macAddress: '00:1B:44:11:3A:C3',
+    lastSeen: '4 minutes ago',
+    bandwidth: '380 Mbps',
+  },
+  {
+    id: '8',
+    name: 'AP-Office-02',
+    type: 'Access Point',
+    status: 'Active',
+    ipAddress: '192.168.1.51',
+    macAddress: '00:1B:44:11:3A:C4',
+    lastSeen: '6 minutes ago',
+    bandwidth: '195 Mbps',
+  },
+  {
+    id: '9',
+    name: 'Storage-NAS',
+    type: 'Storage',
+    status: 'Active',
+    ipAddress: '192.168.1.100',
+    macAddress: '00:1B:44:11:3A:C5',
+    lastSeen: '1 minute ago',
+    bandwidth: '540 Mbps',
+  },
+  {
+    id: '10',
+    name: 'Printer-Office',
+    type: 'Printer',
+    status: 'Active',
+    ipAddress: '192.168.1.150',
+    macAddress: '00:1B:44:11:3A:C6',
+    lastSeen: '10 minutes ago',
+    bandwidth: '2 Mbps',
+  },
+];
+
+export function App() {
+  const [selectedItems, setSelectedItems] = useState<DeviceItem[]>([]);
+  const [filteringText, setFilteringText] = useState('');
+  const [currentPageIndex, setCurrentPageIndex] = useState(1);
+  const [dismissedWarning, setDismissedWarning] = useState(false);
+
+  const itemsPerPage = 10;
+
+  const filteredDevices = allDevices.filter(
+    (device) =>
+      device.name.toLowerCase().includes(filteringText.toLowerCase()) ||
+      device.type.toLowerCase().includes(filteringText.toLowerCase()) ||
+      device.ipAddress.toLowerCase().includes(filteringText.toLowerCase()),
+  );
+
+  const paginatedDevices = filteredDevices.slice(
+    (currentPageIndex - 1) * itemsPerPage,
+    currentPageIndex * itemsPerPage,
+  );
+
+  return (
+    <AppLayout
+      navigationHide
+      toolsHide
+      breadcrumbs={
+        <BreadcrumbGroup
+          items={[
+            { text: 'Service', href: '#' },
+            { text: 'Administrative Dashboard', href: '#' },
+          ]}
+        />
+      }
+      content={
+        <ContentLayout
+          header={
+            <SpaceBetween size="m">
+              <Header
+                variant="h1"
+                description="Network Traffic, Credit Usage, and Your Devices"
+                actions={
+                  <Button variant="primary" iconName="external" iconAlign="right">
+                    Refresh Data
+                  </Button>
+                }
+              >
+                Network Adminstration Dashboard
+              </Header>
+
+              {!dismissedWarning && (
+                <Flashbar
+                  items={[
+                    {
+                      type: 'warning',
+                      content: 'This is a warning message',
+                      dismissible: true,
+                      onDismiss: () => setDismissedWarning(true),
+                      buttonText: 'Dismiss',
+                    },
+                  ]}
+                />
+              )}
+            </SpaceBetween>
+          }
+        >
+          <SpaceBetween size="l">
+            <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+              <Container>
+                <AreaChart
+                  series={[
+                    {
+                      title: 'Site 1',
+                      type: 'area',
+                      data: networkTrafficData,
+                      color: '#688AE8',
+                    },
+                    {
+                      title: 'Site 2',
+                      type: 'area',
+                      data: networkTrafficData2,
+                      color: '#C33D69',
+                    },
+                  ]}
+                  xDomain={['x1', 'x2', 'x3', 'x4', 'x5', 'x6', 'x7', 'x8', 'x9', 'x10', 'x11', 'x12']}
+                  yDomain={[0, 6]}
+                  i18nStrings={{
+                    filterLabel: 'Filter displayed data',
+                    filterPlaceholder: 'Filter data',
+                    filterSelectedAriaLabel: 'selected',
+                    legendAriaLabel: 'Legend',
+                    chartAriaRoleDescription: 'area chart',
+                    xTickFormatter: (e) => e.toString(),
+                    yTickFormatter: (e) => `y${Math.round(e)}`,
+                  }}
+                  ariaLabel="Network traffic area chart"
+                  height={300}
+                  xScaleType="categorical"
+                  xTitle="Day"
+                  yTitle="Network traffic"
+                  empty={
+                    <Box textAlign="center" color="inherit">
+                      <b>No data available</b>
+                      <Box variant="p" color="inherit">
+                        There is no data available
+                      </Box>
+                    </Box>
+                  }
+                  noMatch={
+                    <Box textAlign="center" color="inherit">
+                      <b>No matching data</b>
+                      <Box variant="p" color="inherit">
+                        There is no matching data to display
+                      </Box>
+                    </Box>
+                  }
+                />
+              </Container>
+
+              <Container>
+                <BarChart
+                  series={[
+                    {
+                      title: 'Site 1',
+                      type: 'bar',
+                      data: creditUsageData,
+                      color: '#688AE8',
+                    },
+                  ]}
+                  xDomain={['x1', 'x2', 'x3', 'x4', 'x5']}
+                  yDomain={[0, 6]}
+                  i18nStrings={{
+                    filterLabel: 'Filter displayed data',
+                    filterPlaceholder: 'Filter data',
+                    filterSelectedAriaLabel: 'selected',
+                    legendAriaLabel: 'Legend',
+                    chartAriaRoleDescription: 'bar chart',
+                    xTickFormatter: (e) => e.toString(),
+                    yTickFormatter: (e) => `y${Math.round(e)}`,
+                  }}
+                  ariaLabel="Credit usage bar chart"
+                  height={300}
+                  xScaleType="categorical"
+                  xTitle="Day"
+                  yTitle="Credit Usage"
+                  empty={
+                    <Box textAlign="center" color="inherit">
+                      <b>No data available</b>
+                      <Box variant="p" color="inherit">
+                        There is no data available
+                      </Box>
+                    </Box>
+                  }
+                  noMatch={
+                    <Box textAlign="center" color="inherit">
+                      <b>No matching data</b>
+                      <Box variant="p" color="inherit">
+                        There is no matching data to display
+                      </Box>
+                    </Box>
+                  }
+                />
+              </Container>
+            </Grid>
+
+            <Table
+              columnDefinitions={[
+                {
+                  id: 'name',
+                  header: 'Device Name',
+                  cell: (item) => item.name,
+                  sortingField: 'name',
+                },
+                {
+                  id: 'type',
+                  header: 'Type',
+                  cell: (item) => item.type,
+                  sortingField: 'type',
+                },
+                {
+                  id: 'status',
+                  header: 'Status',
+                  cell: (item) => item.status,
+                  sortingField: 'status',
+                },
+                {
+                  id: 'ipAddress',
+                  header: 'IP Address',
+                  cell: (item) => item.ipAddress,
+                  sortingField: 'ipAddress',
+                },
+                {
+                  id: 'macAddress',
+                  header: 'MAC Address',
+                  cell: (item) => item.macAddress,
+                },
+                {
+                  id: 'lastSeen',
+                  header: 'Last Seen',
+                  cell: (item) => item.lastSeen,
+                },
+                {
+                  id: 'bandwidth',
+                  header: 'Bandwidth',
+                  cell: (item) => item.bandwidth,
+                  sortingField: 'bandwidth',
+                },
+              ]}
+              items={paginatedDevices}
+              loadingText="Loading devices"
+              selectionType="multi"
+              trackBy="id"
+              selectedItems={selectedItems}
+              onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
+              empty={
+                <Box textAlign="center" color="inherit">
+                  <Box padding={{ bottom: 's' }} variant="p" color="inherit">
+                    <b>No devices</b>
+                  </Box>
+                  <Box variant="p" color="inherit">
+                    No devices to display.
+                  </Box>
+                </Box>
+              }
+              filter={
+                <TextFilter
+                  filteringText={filteringText}
+                  filteringPlaceholder="Placeholder"
+                  filteringAriaLabel="Filter devices"
+                  onChange={({ detail }) => {
+                    setFilteringText(detail.filteringText);
+                    setCurrentPageIndex(1);
+                  }}
+                  countText={`${filteredDevices.length} matches`}
+                />
+              }
+              header={
+                <Header
+                  variant="h2"
+                  description="Devices on your local network"
+                  actions={
+                    <Button variant="primary" iconName="external" iconAlign="right">
+                      Add Device
+                    </Button>
+                  }
+                >
+                  My Devices
+                </Header>
+              }
+              pagination={
+                <Pagination
+                  currentPageIndex={currentPageIndex}
+                  onChange={({ detail }) => setCurrentPageIndex(detail.currentPageIndex)}
+                  pagesCount={Math.ceil(filteredDevices.length / itemsPerPage)}
+                  ariaLabels={{
+                    nextPageLabel: 'Next page',
+                    previousPageLabel: 'Previous page',
+                    pageLabel: (pageNumber) => `Page ${pageNumber} of all pages`,
+                  }}
+                />
+              }
+            />
+          </SpaceBetween>
+        </ContentLayout>
+      }
+    />
+  );
+}

--- a/src/pages/network-dashboard/app.tsx
+++ b/src/pages/network-dashboard/app.tsx
@@ -179,7 +179,7 @@ export function App() {
   const itemsPerPage = 10;
 
   const filteredDevices = allDevices.filter(
-    (device) =>
+    device =>
       device.name.toLowerCase().includes(filteringText.toLowerCase()) ||
       device.type.toLowerCase().includes(filteringText.toLowerCase()) ||
       device.ipAddress.toLowerCase().includes(filteringText.toLowerCase()),
@@ -260,8 +260,8 @@ export function App() {
                     filterSelectedAriaLabel: 'selected',
                     legendAriaLabel: 'Legend',
                     chartAriaRoleDescription: 'area chart',
-                    xTickFormatter: (e) => e.toString(),
-                    yTickFormatter: (e) => `y${Math.round(e)}`,
+                    xTickFormatter: e => e.toString(),
+                    yTickFormatter: e => `y${Math.round(e)}`,
                   }}
                   ariaLabel="Network traffic area chart"
                   height={300}
@@ -305,8 +305,8 @@ export function App() {
                     filterSelectedAriaLabel: 'selected',
                     legendAriaLabel: 'Legend',
                     chartAriaRoleDescription: 'bar chart',
-                    xTickFormatter: (e) => e.toString(),
-                    yTickFormatter: (e) => `y${Math.round(e)}`,
+                    xTickFormatter: e => e.toString(),
+                    yTickFormatter: e => `y${Math.round(e)}`,
                   }}
                   ariaLabel="Credit usage bar chart"
                   height={300}
@@ -338,41 +338,41 @@ export function App() {
                 {
                   id: 'name',
                   header: 'Device Name',
-                  cell: (item) => item.name,
+                  cell: item => item.name,
                   sortingField: 'name',
                 },
                 {
                   id: 'type',
                   header: 'Type',
-                  cell: (item) => item.type,
+                  cell: item => item.type,
                   sortingField: 'type',
                 },
                 {
                   id: 'status',
                   header: 'Status',
-                  cell: (item) => item.status,
+                  cell: item => item.status,
                   sortingField: 'status',
                 },
                 {
                   id: 'ipAddress',
                   header: 'IP Address',
-                  cell: (item) => item.ipAddress,
+                  cell: item => item.ipAddress,
                   sortingField: 'ipAddress',
                 },
                 {
                   id: 'macAddress',
                   header: 'MAC Address',
-                  cell: (item) => item.macAddress,
+                  cell: item => item.macAddress,
                 },
                 {
                   id: 'lastSeen',
                   header: 'Last Seen',
-                  cell: (item) => item.lastSeen,
+                  cell: item => item.lastSeen,
                 },
                 {
                   id: 'bandwidth',
                   header: 'Bandwidth',
-                  cell: (item) => item.bandwidth,
+                  cell: item => item.bandwidth,
                   sortingField: 'bandwidth',
                 },
               ]}
@@ -425,7 +425,7 @@ export function App() {
                   ariaLabels={{
                     nextPageLabel: 'Next page',
                     previousPageLabel: 'Previous page',
-                    pageLabel: (pageNumber) => `Page ${pageNumber} of all pages`,
+                    pageLabel: pageNumber => `Page ${pageNumber} of all pages`,
                   }}
                 />
               }

--- a/src/pages/network-dashboard/app.tsx
+++ b/src/pages/network-dashboard/app.tsx
@@ -15,7 +15,7 @@ import Table from '@cloudscape-design/components/table';
 import Box from '@cloudscape-design/components/box';
 import TextFilter from '@cloudscape-design/components/text-filter';
 import Pagination from '@cloudscape-design/components/pagination';
-import Flashbar from '@cloudscape-design/components/flashbar';
+import Alert from '@cloudscape-design/components/alert';
 import ContentLayout from '@cloudscape-design/components/content-layout';
 
 interface DeviceItem {
@@ -219,17 +219,13 @@ export function App() {
               </Header>
 
               {!dismissedWarning && (
-                <Flashbar
-                  items={[
-                    {
-                      type: 'error',
-                      content: 'This is a warning message',
-                      dismissible: true,
-                      onDismiss: () => setDismissedWarning(true),
-                      buttonText: 'Dismiss',
-                    },
-                  ]}
-                />
+                <Alert
+                  type="error"
+                  dismissible
+                  onDismiss={() => setDismissedWarning(true)}
+                >
+                  This is a warning message
+                </Alert>
               )}
             </SpaceBetween>
           }

--- a/src/pages/network-dashboard/app.tsx
+++ b/src/pages/network-dashboard/app.tsx
@@ -219,11 +219,7 @@ export function App() {
               </Header>
 
               {!dismissedWarning && (
-                <Alert
-                  type="error"
-                  dismissible
-                  onDismiss={() => setDismissedWarning(true)}
-                >
+                <Alert type="error" dismissible onDismiss={() => setDismissedWarning(true)}>
                   This is a warning message
                 </Alert>
               )}

--- a/src/pages/network-dashboard/app.tsx
+++ b/src/pages/network-dashboard/app.tsx
@@ -222,7 +222,7 @@ export function App() {
                 <Flashbar
                   items={[
                     {
-                      type: 'warning',
+                      type: 'error',
                       content: 'This is a warning message',
                       dismissible: true,
                       onDismiss: () => setDismissedWarning(true),

--- a/src/pages/network-dashboard/index.tsx
+++ b/src/pages/network-dashboard/index.tsx
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React from 'react';
+import { App } from './app';
+
+import '../../styles/base.scss';
+
+export default function NetworkDashboard() {
+  return <App />;
+}

--- a/src/pages/weather-dashboard/app.tsx
+++ b/src/pages/weather-dashboard/app.tsx
@@ -1,0 +1,408 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React, { useEffect, useState } from 'react';
+import AppLayout from '@cloudscape-design/components/app-layout';
+import ContentLayout from '@cloudscape-design/components/content-layout';
+import Header from '@cloudscape-design/components/header';
+import Container from '@cloudscape-design/components/container';
+import Box from '@cloudscape-design/components/box';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Grid from '@cloudscape-design/components/grid';
+import Button from '@cloudscape-design/components/button';
+import Input from '@cloudscape-design/components/input';
+import Select from '@cloudscape-design/components/select';
+import Spinner from '@cloudscape-design/components/spinner';
+import Alert from '@cloudscape-design/components/alert';
+import Cards from '@cloudscape-design/components/cards';
+import Badge from '@cloudscape-design/components/badge';
+import AreaChart from '@cloudscape-design/components/area-chart';
+
+interface WeatherData {
+  current: {
+    temperature: number;
+    apparent_temperature: number;
+    relative_humidity: number;
+    weather_code: number;
+    wind_speed: number;
+    precipitation: number;
+    weather_description: string;
+  };
+  hourly: {
+    time: string[];
+    temperature_2m: number[];
+    precipitation: number[];
+  };
+  location: {
+    name: string;
+    latitude: number;
+    longitude: number;
+    country: string;
+  };
+}
+
+const getWeatherDescription = (code: number): string => {
+  const descriptions: { [key: number]: string } = {
+    0: 'Clear sky',
+    1: 'Mainly clear',
+    2: 'Partly cloudy',
+    3: 'Overcast',
+    45: 'Foggy',
+    48: 'Depositing rime fog',
+    51: 'Light drizzle',
+    53: 'Moderate drizzle',
+    55: 'Dense drizzle',
+    61: 'Slight rain',
+    63: 'Moderate rain',
+    65: 'Heavy rain',
+    71: 'Slight snow',
+    73: 'Moderate snow',
+    75: 'Heavy snow',
+    77: 'Snow grains',
+    80: 'Slight rain showers',
+    81: 'Moderate rain showers',
+    82: 'Violent rain showers',
+    85: 'Slight snow showers',
+    86: 'Heavy snow showers',
+    95: 'Thunderstorm',
+    96: 'Thunderstorm with slight hail',
+    99: 'Thunderstorm with heavy hail',
+  };
+  return descriptions[code] || 'Unknown';
+};
+
+const getWeatherIcon = (code: number): string => {
+  if (code === 0) return '☀️';
+  if (code <= 3) return '⛅';
+  if (code === 45 || code === 48) return '🌫️';
+  if (code >= 51 && code <= 67) return '🌧️';
+  if (code >= 71 && code <= 86) return '❄️';
+  if (code >= 95) return '⛈️';
+  return '🌡️';
+};
+
+const getTemperatureColor = (temp: number): string => {
+  if (temp < 0) return 'blue';
+  if (temp < 10) return 'teal';
+  if (temp < 20) return 'green';
+  if (temp < 25) return 'orange';
+  return 'red';
+};
+
+export function App() {
+  const [location, setLocation] = useState('New York');
+  const [searchInput, setSearchInput] = useState('');
+  const [weatherData, setWeatherData] = useState<WeatherData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [selectedPreset, setSelectedPreset] = useState({ label: 'New York', value: 'New York' });
+
+  const presets = [
+    { label: 'New York', value: 'New York' },
+    { label: 'London', value: 'London' },
+    { label: 'Tokyo', value: 'Tokyo' },
+    { label: 'Sydney', value: 'Sydney' },
+    { label: 'Paris', value: 'Paris' },
+    { label: 'Singapore', value: 'Singapore' },
+    { label: 'Dubai', value: 'Dubai' },
+    { label: 'Toronto', value: 'Toronto' },
+  ];
+
+  const fetchWeather = async (city: string) => {
+    setLoading(true);
+    setError('');
+    try {
+      const geoResponse = await fetch(
+        `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(city)}&count=1&language=en&format=json`,
+      );
+      const geoData = await geoResponse.json();
+
+      if (!geoData.results || geoData.results.length === 0) {
+        setError(`City "${city}" not found. Please try another location.`);
+        setWeatherData(null);
+        setLoading(false);
+        return;
+      }
+
+      const { latitude, longitude, name, country } = geoData.results[0];
+
+      const weatherResponse = await fetch(
+        `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&current=temperature_2m,apparent_temperature,relative_humidity,weather_code,wind_speed,precipitation&hourly=temperature_2m,precipitation&temperature_unit=fahrenheit&wind_speed_unit=mph&precipitation_unit=inch&timezone=auto`,
+      );
+      const weatherDataResponse = await weatherResponse.json();
+
+      const hourlyData = weatherDataResponse.hourly || { time: [], temperature_2m: [], precipitation: [] };
+      const current = weatherDataResponse.current || {};
+      const hourlyTime = Array.isArray(hourlyData.time) ? hourlyData.time.slice(0, 24) : [];
+      const hourlyTemps = Array.isArray(hourlyData.temperature_2m) ? hourlyData.temperature_2m.slice(0, 24) : [];
+      const hourlyPrecip = Array.isArray(hourlyData.precipitation) ? hourlyData.precipitation.slice(0, 24) : [];
+
+      setWeatherData({
+        current: {
+          temperature: current.temperature_2m || 0,
+          apparent_temperature: current.apparent_temperature || 0,
+          relative_humidity: current.relative_humidity || 0,
+          weather_code: current.weather_code || 0,
+          wind_speed: current.wind_speed || 0,
+          precipitation: current.precipitation || 0,
+          weather_description: getWeatherDescription(current.weather_code || 0),
+        },
+        hourly: {
+          time: hourlyTime,
+          temperature_2m: hourlyTemps,
+          precipitation: hourlyPrecip,
+        },
+        location: {
+          name,
+          latitude,
+          longitude,
+          country,
+        },
+      });
+    } catch (err) {
+      setError('Failed to fetch weather data. Please try again.');
+      setWeatherData(null);
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    fetchWeather(location);
+  }, []);
+
+  const handleSearch = () => {
+    if (searchInput.trim()) {
+      setLocation(searchInput);
+      fetchWeather(searchInput);
+      setSearchInput('');
+    }
+  };
+
+  const handlePresetSelect = (preset: typeof selectedPreset) => {
+    setSelectedPreset(preset);
+    setLocation(preset.value);
+    fetchWeather(preset.value);
+  };
+
+  const chartData = weatherData
+    ? weatherData.hourly.time.map((time, index) => ({
+        x: new Date(time).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' }),
+        y: Math.round(weatherData.hourly.temperature_2m[index] * 10) / 10,
+      }))
+    : [];
+
+  return (
+    <AppLayout
+      navigationHide
+      toolsHide
+      content={
+        <ContentLayout
+          header={
+            <Header variant="h1">Weather Dashboard</Header>
+          }
+        >
+          <SpaceBetween size="l">
+            <Container header={<Header variant="h2">Search Location</Header>}>
+              <SpaceBetween size="m">
+                <Grid gridDefinition={[{ colspan: { default: 12, xs: 12, s: 6, m: 6, l: 6 } }, { colspan: { default: 12, xs: 12, s: 6, m: 6, l: 6 } }]}>
+                  <Input
+                    value={searchInput}
+                    onChange={({ detail }) => setSearchInput(detail.value)}
+                    placeholder="Enter a city name..."
+                    onKeyDown={(event) => {
+                      if (event.detail.key === 'Enter') {
+                        handleSearch();
+                      }
+                    }}
+                  />
+                  <Button onClick={handleSearch} variant="primary">
+                    Search
+                  </Button>
+                </Grid>
+                <Box>
+                  <Box variant="small" color="text-status-inactive">
+                    Quick access:
+                  </Box>
+                  <SpaceBetween size="xs" direction="horizontal">
+                    {presets.map((preset) => (
+                      <Button
+                        key={preset.value}
+                        variant={selectedPreset.value === preset.value ? 'primary' : 'normal'}
+                        onClick={() => handlePresetSelect(preset)}
+                      >
+                        {preset.label}
+                      </Button>
+                    ))}
+                  </SpaceBetween>
+                </Box>
+              </SpaceBetween>
+            </Container>
+
+            {error && (
+              <Alert type="error" header="Error">
+                {error}
+              </Alert>
+            )}
+
+            {loading && (
+              <Container header={<Header variant="h2">Loading Weather Data</Header>}>
+                <Box textAlign="center" padding={{ vertical: 'l' }}>
+                  <Spinner />
+                </Box>
+              </Container>
+            )}
+
+            {weatherData && !loading && (
+              <>
+                <Container
+                  header={
+                    <Header
+                      variant="h2"
+                      description={`${weatherData.location.name}, ${weatherData.location.country}`}
+                    >
+                      Current Weather
+                    </Header>
+                  }
+                >
+                  <Grid
+                    gridDefinition={[
+                      { colspan: { default: 12, xs: 12, s: 12, m: 6, l: 4 } },
+                      { colspan: { default: 12, xs: 12, s: 12, m: 6, l: 4 } },
+                      { colspan: { default: 12, xs: 12, s: 12, m: 6, l: 4 } },
+                      { colspan: { default: 12, xs: 12, s: 12, m: 6, l: 4 } },
+                      { colspan: { default: 12, xs: 12, s: 12, m: 6, l: 4 } },
+                      { colspan: { default: 12, xs: 12, s: 12, m: 6, l: 4 } },
+                    ]}
+                  >
+                    <Container>
+                      <SpaceBetween size="s">
+                        <Box variant="h3">{getWeatherIcon(weatherData.current.weather_code)}</Box>
+                        <Box variant="p" color="text-status-inactive">
+                          Condition
+                        </Box>
+                        <Box variant="p">{weatherData.current.weather_description}</Box>
+                      </SpaceBetween>
+                    </Container>
+
+                    <Container>
+                      <SpaceBetween size="s">
+                        <Box variant="h3" color={getTemperatureColor(weatherData.current.temperature)}>
+                          {Math.round(weatherData.current.temperature)}°F
+                        </Box>
+                        <Box variant="p" color="text-status-inactive">
+                          Temperature
+                        </Box>
+                        <Badge content="Feels like" color="blue" />
+                        <Box variant="p">{Math.round(weatherData.current.apparent_temperature)}°F</Box>
+                      </SpaceBetween>
+                    </Container>
+
+                    <Container>
+                      <SpaceBetween size="s">
+                        <Box variant="h3">{weatherData.current.relative_humidity}%</Box>
+                        <Box variant="p" color="text-status-inactive">
+                          Humidity
+                        </Box>
+                      </SpaceBetween>
+                    </Container>
+
+                    <Container>
+                      <SpaceBetween size="s">
+                        <Box variant="h3">{Math.round(weatherData.current.wind_speed)} mph</Box>
+                        <Box variant="p" color="text-status-inactive">
+                          Wind Speed
+                        </Box>
+                      </SpaceBetween>
+                    </Container>
+
+                    <Container>
+                      <SpaceBetween size="s">
+                        <Box variant="h3">{weatherData.current.precipitation}</Box>
+                        <Box variant="p" color="text-status-inactive">
+                          Precipitation
+                        </Box>
+                      </SpaceBetween>
+                    </Container>
+
+                    <Container>
+                      <SpaceBetween size="s">
+                        <Box variant="h3">{weatherData.location.latitude.toFixed(2)}°</Box>
+                        <Box variant="p" color="text-status-inactive">
+                          Latitude
+                        </Box>
+                        <Box variant="p">{weatherData.location.longitude.toFixed(2)}°</Box>
+                        <Box variant="p" color="text-status-inactive">
+                          Longitude
+                        </Box>
+                      </SpaceBetween>
+                    </Container>
+                  </Grid>
+                </Container>
+
+                {chartData.length > 0 && (
+                  <Container header={<Header variant="h2">24-Hour Temperature Forecast</Header>}>
+                    <AreaChart
+                      series={[
+                        {
+                          title: 'Temperature (°F)',
+                          type: 'area',
+                          data: chartData,
+                        },
+                      ]}
+                      i18nStrings={{
+                        yTickFormatter: (e) => `${Math.round(e)}°`,
+                      }}
+                      ariaLabel="24-hour temperature forecast"
+                      height={300}
+                      hideFilter
+                      hideLegend={false}
+                    />
+                  </Container>
+                )}
+
+                <Container header={<Header variant="h2">Hourly Breakdown</Header>}>
+                  <Cards
+                    cardDefinition={{
+                      sections: [
+                        {
+                          id: 'time',
+                          header: (item) => new Date(item.time).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' }),
+                          content: () => null,
+                        },
+                        {
+                          id: 'temperature',
+                          header: 'Temperature',
+                          content: (item) => `${Math.round(item.temperature * 10) / 10}°F`,
+                        },
+                        {
+                          id: 'precipitation',
+                          header: 'Precipitation',
+                          content: (item) => `${item.precipitation}"`,
+                        },
+                      ],
+                    }}
+                    items={weatherData.hourly.time.map((time, index) => ({
+                      time,
+                      temperature: weatherData.hourly.temperature_2m[index],
+                      precipitation: weatherData.hourly.precipitation[index],
+                    }))}
+                    cardsPerRow={[
+                      { cards: 1, minWidth: 0 },
+                      { cards: 2, minWidth: 600 },
+                      { cards: 4, minWidth: 1200 },
+                    ]}
+                    empty={
+                      <Box textAlign="center" padding={{ vertical: 'l' }}>
+                        No hourly data available
+                      </Box>
+                    }
+                  />
+                </Container>
+              </>
+            )}
+          </SpaceBetween>
+        </ContentLayout>
+      }
+    />
+  );
+}

--- a/src/pages/weather-dashboard/app.tsx
+++ b/src/pages/weather-dashboard/app.tsx
@@ -196,20 +196,21 @@ export function App() {
       navigationHide
       toolsHide
       content={
-        <ContentLayout
-          header={
-            <Header variant="h1">Weather Dashboard</Header>
-          }
-        >
+        <ContentLayout header={<Header variant="h1">Weather Dashboard</Header>}>
           <SpaceBetween size="l">
             <Container header={<Header variant="h2">Search Location</Header>}>
               <SpaceBetween size="m">
-                <Grid gridDefinition={[{ colspan: { default: 12, xs: 12, s: 6, m: 6, l: 6 } }, { colspan: { default: 12, xs: 12, s: 6, m: 6, l: 6 } }]}>
+                <Grid
+                  gridDefinition={[
+                    { colspan: { default: 12, xs: 12, s: 6, m: 6, l: 6 } },
+                    { colspan: { default: 12, xs: 12, s: 6, m: 6, l: 6 } },
+                  ]}
+                >
                   <Input
                     value={searchInput}
                     onChange={({ detail }) => setSearchInput(detail.value)}
                     placeholder="Enter a city name..."
-                    onKeyDown={(event) => {
+                    onKeyDown={event => {
                       if (event.detail.key === 'Enter') {
                         handleSearch();
                       }
@@ -224,7 +225,7 @@ export function App() {
                     Quick access:
                   </Box>
                   <SpaceBetween size="xs" direction="horizontal">
-                    {presets.map((preset) => (
+                    {presets.map(preset => (
                       <Button
                         key={preset.value}
                         variant={selectedPreset.value === preset.value ? 'primary' : 'normal'}
@@ -256,10 +257,7 @@ export function App() {
               <>
                 <Container
                   header={
-                    <Header
-                      variant="h2"
-                      description={`${weatherData.location.name}, ${weatherData.location.country}`}
-                    >
+                    <Header variant="h2" description={`${weatherData.location.name}, ${weatherData.location.country}`}>
                       Current Weather
                     </Header>
                   }
@@ -350,7 +348,7 @@ export function App() {
                         },
                       ]}
                       i18nStrings={{
-                        yTickFormatter: (e) => `${Math.round(e)}°`,
+                        yTickFormatter: e => `${Math.round(e)}°`,
                       }}
                       ariaLabel="24-hour temperature forecast"
                       height={300}
@@ -366,18 +364,19 @@ export function App() {
                       sections: [
                         {
                           id: 'time',
-                          header: (item) => new Date(item.time).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' }),
+                          header: item =>
+                            new Date(item.time).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' }),
                           content: () => null,
                         },
                         {
                           id: 'temperature',
                           header: 'Temperature',
-                          content: (item) => `${Math.round(item.temperature * 10) / 10}°F`,
+                          content: item => `${Math.round(item.temperature * 10) / 10}°F`,
                         },
                         {
                           id: 'precipitation',
                           header: 'Precipitation',
-                          content: (item) => `${item.precipitation}"`,
+                          content: item => `${item.precipitation}"`,
                         },
                       ],
                     }}

--- a/src/pages/weather-dashboard/index.tsx
+++ b/src/pages/weather-dashboard/index.tsx
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React from 'react';
+import { App } from './app';
+
+import '../../styles/base.scss';
+
+export default function WeatherDashboard() {
+  return <App />;
+}


### PR DESCRIPTION
### Purpose

This pull request introduces two new dashboard examples to showcase the capabilities of the UI components in a practical, real-world context. The goal is to provide users with comprehensive examples of how to build data-driven dashboards for network administration and weather forecasting.

### Code changes

- **Added Network Administration Dashboard:** A new page at `/network-dashboard` has been created. It features components for monitoring network traffic via charts and managing a list of network devices in a table.
- **Added Weather Dashboard:** A new page at `/weather-dashboard` has been implemented. This dashboard fetches real-time weather data from the open-meteo API and displays current conditions, a 24-hour temperature forecast chart, and an hourly data breakdown.
- **Updated Demo List:** The main `index.tsx` page has been updated to include links and descriptions for the two new dashboards, making them discoverable from the main application page.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 28`

🔗 [Edit in Builder.io](https://builder.io/app/projects/82a0d72280b64a4e9c841241494d5ab4/nova-space)

👀 [Preview Link](https://82a0d72280b64a4e9c841241494d5ab4-nova-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>82a0d72280b64a4e9c841241494d5ab4</projectId>-->
<!--<branchName>nova-space</branchName>-->