### PR TITLE
feat: Add Network Dashboard page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -62,6 +62,12 @@ const demos = [
   { route: '/form-validation', title: 'Form Validation', description: 'Form validation demo.', category: 'Forms' },
   { route: '/manage-tags', title: 'Manage Tags', description: 'Tag management demo.', category: 'Components' },
   {
+    route: '/network-dashboard',
+    title: 'Network Dashboard',
+    description: 'Network administration dashboard with traffic monitoring and device management.',
+    category: 'Dashboards',
+  },
+  {
     route: '/non-console',
     title: 'Top Navigation',
     description: 'Non-console top navigation.',

--- a/src/pages/network-dashboard/index.tsx
+++ b/src/pages/network-dashboard/index.tsx
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { App } from './root';
+
+const root = createRoot(document.getElementById('app')!);
+root.render(<App />);

--- a/src/pages/network-dashboard/index.tsx
+++ b/src/pages/network-dashboard/index.tsx
@@ -1,9 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 import React from 'react';
-import { createRoot } from 'react-dom/client';
-
 import { App } from './root';
 
-const root = createRoot(document.getElementById('app')!);
-root.render(<App />);
+export default function NetworkDashboard() {
+  return <App />;
+}

--- a/src/pages/network-dashboard/network-dashboard.module.scss
+++ b/src/pages/network-dashboard/network-dashboard.module.scss
@@ -1,0 +1,86 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+.chartContainer {
+  padding: 16px;
+  background: #fff;
+  box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.25);
+}
+
+.chartWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.legendContainer {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding-top: 16px;
+}
+
+.legendItem {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.legendBox {
+  width: 14px;
+  height: 14px;
+  border-radius: 2px;
+  display: inline-block;
+  border: 1px solid currentColor;
+}
+
+.legendDash {
+  width: 12px;
+  height: 3px;
+  display: inline-block;
+  background: repeating-linear-gradient(
+    to right,
+    #5f6b7a 0,
+    #5f6b7a 6px,
+    transparent 6px,
+    transparent 8px
+  );
+}
+
+.legendLabel {
+  color: #000716;
+  font-family: 'Open Sans', -apple-system, Roboto, Helvetica, sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 22px;
+}
+
+.tableHeader {
+  display: flex;
+  align-items: center;
+  gap: 113px;
+  width: 100%;
+}
+
+.paginationWrapper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
+@media (max-width: 768px) {
+  .tableHeader {
+    flex-direction: column;
+    gap: 16px;
+    align-items: stretch;
+  }
+
+  .paginationWrapper {
+    margin-left: 0;
+  }
+
+  .legendContainer {
+    flex-wrap: wrap;
+  }
+}

--- a/src/pages/network-dashboard/network-dashboard.module.scss
+++ b/src/pages/network-dashboard/network-dashboard.module.scss
@@ -38,18 +38,17 @@
   width: 12px;
   height: 3px;
   display: inline-block;
-  background: repeating-linear-gradient(
-    to right,
-    #5f6b7a 0,
-    #5f6b7a 6px,
-    transparent 6px,
-    transparent 8px
-  );
+  background: repeating-linear-gradient(to right, #5f6b7a 0, #5f6b7a 6px, transparent 6px, transparent 8px);
 }
 
 .legendLabel {
   color: #000716;
-  font-family: 'Open Sans', -apple-system, Roboto, Helvetica, sans-serif;
+  font-family:
+    'Open Sans',
+    -apple-system,
+    Roboto,
+    Helvetica,
+    sans-serif;
   font-size: 14px;
   font-weight: 400;
   line-height: 22px;

--- a/src/pages/network-dashboard/root.tsx
+++ b/src/pages/network-dashboard/root.tsx
@@ -156,18 +156,15 @@ export function App() {
     },
   ]);
 
-  const { items, actions, filteredItemsCount, collectionProps, filterProps, paginationProps } = useCollection(
-    devices,
-    {
-      filtering: {
-        empty: <div>No devices</div>,
-        noMatch: <div>No matches found</div>,
-      },
-      pagination: { pageSize: 10 },
-      sorting: {},
-      selection: {},
+  const { items, actions, filteredItemsCount, collectionProps, filterProps, paginationProps } = useCollection(devices, {
+    filtering: {
+      empty: <div>No devices</div>,
+      noMatch: <div>No matches found</div>,
     },
-  );
+    pagination: { pageSize: 10 },
+    sorting: {},
+    selection: {},
+  });
 
   return (
     <CustomAppLayout
@@ -212,9 +209,8 @@ export function App() {
                     filterPlaceholder: 'Filter data',
                     legendAriaLabel: 'Legend',
                     chartAriaRoleDescription: 'area chart',
-                    xTickFormatter: (value) =>
-                      value instanceof Date ? `x${value.getDate()}` : String(value),
-                    yTickFormatter: (value) => `y${Number(value).toFixed(0)}`,
+                    xTickFormatter: value => (value instanceof Date ? `x${value.getDate()}` : String(value)),
+                    yTickFormatter: value => `y${Number(value).toFixed(0)}`,
                   }}
                   hideFilter
                   hideLegend={false}
@@ -254,8 +250,8 @@ export function App() {
                     filterPlaceholder: 'Filter data',
                     legendAriaLabel: 'Legend',
                     chartAriaRoleDescription: 'bar chart',
-                    xTickFormatter: (value) => String(value),
-                    yTickFormatter: (value) => `y${Number(value).toFixed(0)}`,
+                    xTickFormatter: value => String(value),
+                    yTickFormatter: value => `y${Number(value).toFixed(0)}`,
                   }}
                   hideFilter
                   hideLegend={false}

--- a/src/pages/network-dashboard/root.tsx
+++ b/src/pages/network-dashboard/root.tsx
@@ -8,7 +8,7 @@ import BarChart from '@cloudscape-design/components/bar-chart';
 import BreadcrumbGroup from '@cloudscape-design/components/breadcrumb-group';
 import Button from '@cloudscape-design/components/button';
 import Container from '@cloudscape-design/components/container';
-import Flashbar from '@cloudscape-design/components/flashbar';
+import Alert from '@cloudscape-design/components/alert';
 import Grid from '@cloudscape-design/components/grid';
 import Header from '@cloudscape-design/components/header';
 import Pagination from '@cloudscape-design/components/pagination';
@@ -145,16 +145,7 @@ const COLUMN_DEFINITIONS = [
 
 export function App() {
   const [devices] = useState(generateDevices());
-  const [flashbarItems, setFlashbarItems] = useState([
-    {
-      type: 'error' as const,
-      content: 'This is a warning message',
-      dismissible: true,
-      dismissLabel: 'Dismiss',
-      onDismiss: () => setFlashbarItems([]),
-      id: 'warning-message',
-    },
-  ]);
+  const [alertVisible, setAlertVisible] = useState(true);
 
   const { items, actions, filteredItemsCount, collectionProps, filterProps, paginationProps } = useCollection(devices, {
     filtering: {
@@ -178,7 +169,17 @@ export function App() {
           ]}
         />
       }
-      notifications={<Flashbar items={flashbarItems} />}
+      notifications={
+        alertVisible ? (
+          <Alert
+            type="error"
+            dismissible
+            onDismiss={() => setAlertVisible(false)}
+          >
+            This is a warning message
+          </Alert>
+        ) : null
+      }
       content={
         <SpaceBetween size="l">
           <Header

--- a/src/pages/network-dashboard/root.tsx
+++ b/src/pages/network-dashboard/root.tsx
@@ -1,0 +1,328 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState } from 'react';
+
+import { useCollection } from '@cloudscape-design/collection-hooks';
+import AreaChart from '@cloudscape-design/components/area-chart';
+import BarChart from '@cloudscape-design/components/bar-chart';
+import BreadcrumbGroup from '@cloudscape-design/components/breadcrumb-group';
+import Button from '@cloudscape-design/components/button';
+import Container from '@cloudscape-design/components/container';
+import Flashbar from '@cloudscape-design/components/flashbar';
+import Grid from '@cloudscape-design/components/grid';
+import Header from '@cloudscape-design/components/header';
+import Pagination from '@cloudscape-design/components/pagination';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Table from '@cloudscape-design/components/table';
+import TextFilter from '@cloudscape-design/components/text-filter';
+
+import { CustomAppLayout } from '../commons/common-components';
+
+import '../../styles/base.scss';
+import styles from './network-dashboard.module.scss';
+
+// Sample data for Network Traffic (Area Chart)
+const networkTrafficSeries = [
+  {
+    title: 'Site 1',
+    type: 'area' as const,
+    data: [
+      { x: new Date(2024, 0, 1), y: 3 },
+      { x: new Date(2024, 0, 2), y: 3.5 },
+      { x: new Date(2024, 0, 3), y: 3.2 },
+      { x: new Date(2024, 0, 4), y: 3.8 },
+      { x: new Date(2024, 0, 5), y: 4.2 },
+      { x: new Date(2024, 0, 6), y: 5 },
+      { x: new Date(2024, 0, 7), y: 5.2 },
+      { x: new Date(2024, 0, 8), y: 4.8 },
+      { x: new Date(2024, 0, 9), y: 4.5 },
+      { x: new Date(2024, 0, 10), y: 3.8 },
+      { x: new Date(2024, 0, 11), y: 3.5 },
+      { x: new Date(2024, 0, 12), y: 3.2 },
+    ],
+    valueFormatter: (value: number) => `${value.toFixed(1)} GB`,
+  },
+  {
+    title: 'Site 2',
+    type: 'area' as const,
+    data: [
+      { x: new Date(2024, 0, 1), y: 2 },
+      { x: new Date(2024, 0, 2), y: 2.8 },
+      { x: new Date(2024, 0, 3), y: 2.5 },
+      { x: new Date(2024, 0, 4), y: 3.2 },
+      { x: new Date(2024, 0, 5), y: 3.8 },
+      { x: new Date(2024, 0, 6), y: 4.5 },
+      { x: new Date(2024, 0, 7), y: 4.8 },
+      { x: new Date(2024, 0, 8), y: 4.2 },
+      { x: new Date(2024, 0, 9), y: 3.8 },
+      { x: new Date(2024, 0, 10), y: 3 },
+      { x: new Date(2024, 0, 11), y: 2.5 },
+      { x: new Date(2024, 0, 12), y: 2.2 },
+    ],
+    valueFormatter: (value: number) => `${value.toFixed(1)} GB`,
+  },
+];
+
+// Sample data for Credit Usage (Bar Chart)
+const creditUsageSeries = [
+  {
+    title: 'Site 1',
+    type: 'bar' as const,
+    data: [
+      { x: 'Day 1', y: 183 },
+      { x: 'Day 2', y: 257 },
+      { x: 'Day 3', y: 213 },
+      { x: 'Day 4', y: 122 },
+      { x: 'Day 5', y: 210 },
+    ],
+    valueFormatter: (value: number) => `${value} credits`,
+  },
+];
+
+// Sample device data
+const generateDevices = () => {
+  const devices = [];
+  for (let i = 1; i <= 13; i++) {
+    devices.push({
+      id: `device-${i}`,
+      name: `Device ${i}`,
+      type: 'Network Device',
+      status: 'Active',
+      ipAddress: `192.168.1.${i}`,
+      macAddress: `00:1B:44:11:3A:${i.toString().padStart(2, '0')}`,
+      location: `Building ${Math.ceil(i / 3)}`,
+      lastSeen: '2024-01-09',
+    });
+  }
+  return devices;
+};
+
+const COLUMN_DEFINITIONS = [
+  {
+    id: 'name',
+    header: 'Device Name',
+    cell: (item: any) => item.name,
+    sortingField: 'name',
+    isRowHeader: true,
+  },
+  {
+    id: 'type',
+    header: 'Type',
+    cell: (item: any) => item.type,
+    sortingField: 'type',
+  },
+  {
+    id: 'status',
+    header: 'Status',
+    cell: (item: any) => item.status,
+    sortingField: 'status',
+  },
+  {
+    id: 'ipAddress',
+    header: 'IP Address',
+    cell: (item: any) => item.ipAddress,
+    sortingField: 'ipAddress',
+  },
+  {
+    id: 'macAddress',
+    header: 'MAC Address',
+    cell: (item: any) => item.macAddress,
+    sortingField: 'macAddress',
+  },
+  {
+    id: 'location',
+    header: 'Location',
+    cell: (item: any) => item.location,
+    sortingField: 'location',
+  },
+  {
+    id: 'lastSeen',
+    header: 'Last Seen',
+    cell: (item: any) => item.lastSeen,
+    sortingField: 'lastSeen',
+  },
+];
+
+export function App() {
+  const [devices] = useState(generateDevices());
+  const [flashbarItems, setFlashbarItems] = useState([
+    {
+      type: 'warning' as const,
+      content: 'This is a warning message',
+      dismissible: true,
+      dismissLabel: 'Dismiss',
+      onDismiss: () => setFlashbarItems([]),
+      id: 'warning-message',
+    },
+  ]);
+
+  const { items, actions, filteredItemsCount, collectionProps, filterProps, paginationProps } = useCollection(
+    devices,
+    {
+      filtering: {
+        empty: <div>No devices</div>,
+        noMatch: <div>No matches found</div>,
+      },
+      pagination: { pageSize: 10 },
+      sorting: {},
+      selection: {},
+    },
+  );
+
+  return (
+    <CustomAppLayout
+      navigationHide
+      toolsHide
+      breadcrumbs={
+        <BreadcrumbGroup
+          items={[
+            { text: 'Service', href: '#' },
+            { text: 'Administrative Dashboard', href: '#' },
+          ]}
+        />
+      }
+      notifications={<Flashbar items={flashbarItems} />}
+      content={
+        <SpaceBetween size="l">
+          <Header
+            variant="h1"
+            description="Network Traffic, Credit Usage, and Your Devices"
+            actions={
+              <Button variant="primary" iconName="external" iconAlign="right">
+                Refresh Data
+              </Button>
+            }
+          >
+            Network Administration Dashboard
+          </Header>
+
+          <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+            <Container className={styles.chartContainer}>
+              <div className={styles.chartWrapper}>
+                <Header variant="h2">Network traffic</Header>
+                <AreaChart
+                  series={networkTrafficSeries}
+                  height={300}
+                  xScaleType="time"
+                  yTitle="Traffic"
+                  xTitle="Day"
+                  ariaLabel="Network traffic area chart"
+                  i18nStrings={{
+                    filterLabel: 'Filter displayed data',
+                    filterPlaceholder: 'Filter data',
+                    legendAriaLabel: 'Legend',
+                    chartAriaRoleDescription: 'area chart',
+                    xTickFormatter: (value) => {
+                      const date = new Date(value);
+                      return `x${date.getDate()}`;
+                    },
+                    yTickFormatter: (value) => `y${value}`,
+                  }}
+                  hideFilter
+                  hideLegend={false}
+                  statusType="finished"
+                  detailPopoverSize="medium"
+                  emphasizeBaselineAxis={false}
+                />
+                <div className={styles.legendContainer}>
+                  <div className={styles.legendItem}>
+                    <span className={styles.legendBox} style={{ backgroundColor: '#688AE8' }}></span>
+                    <span className={styles.legendLabel}>Site 1</span>
+                  </div>
+                  <div className={styles.legendItem}>
+                    <span className={styles.legendBox} style={{ backgroundColor: '#C33D69' }}></span>
+                    <span className={styles.legendLabel}>Site 2</span>
+                  </div>
+                  <div className={styles.legendItem}>
+                    <span className={styles.legendDash}></span>
+                    <span className={styles.legendLabel}>Performance goal</span>
+                  </div>
+                </div>
+              </div>
+            </Container>
+
+            <Container className={styles.chartContainer}>
+              <div className={styles.chartWrapper}>
+                <Header variant="h2">Credit Usage</Header>
+                <BarChart
+                  series={creditUsageSeries}
+                  height={300}
+                  xScaleType="categorical"
+                  yTitle="Credits"
+                  xTitle="Day"
+                  ariaLabel="Credit usage bar chart"
+                  i18nStrings={{
+                    filterLabel: 'Filter displayed data',
+                    filterPlaceholder: 'Filter data',
+                    legendAriaLabel: 'Legend',
+                    chartAriaRoleDescription: 'bar chart',
+                    xTickFormatter: (value) => value,
+                    yTickFormatter: (value) => `y${value}`,
+                  }}
+                  hideFilter
+                  hideLegend={false}
+                  statusType="finished"
+                  detailPopoverSize="medium"
+                  emphasizeBaselineAxis={false}
+                />
+                <div className={styles.legendContainer}>
+                  <div className={styles.legendItem}>
+                    <span className={styles.legendBox} style={{ backgroundColor: '#688AE8' }}></span>
+                    <span className={styles.legendLabel}>Site 1</span>
+                  </div>
+                  <div className={styles.legendItem}>
+                    <span className={styles.legendDash}></span>
+                    <span className={styles.legendLabel}>Performance goal</span>
+                  </div>
+                </div>
+              </div>
+            </Container>
+          </Grid>
+
+          <Container>
+            <SpaceBetween size="l">
+              <Header
+                variant="h2"
+                description="Devices on your local network"
+                actions={
+                  <Button variant="primary" iconName="external" iconAlign="right">
+                    Add Device
+                  </Button>
+                }
+              >
+                My Devices
+              </Header>
+
+              <Table
+                {...collectionProps}
+                columnDefinitions={COLUMN_DEFINITIONS}
+                items={items}
+                selectionType="multi"
+                variant="container"
+                stickyHeader
+                header={
+                  <div className={styles.tableHeader}>
+                    <TextFilter
+                      {...filterProps}
+                      filteringPlaceholder="Placeholder"
+                      filteringAriaLabel="Filter devices"
+                      countText={`${filteredItemsCount} matches`}
+                    />
+                    <div className={styles.paginationWrapper}>
+                      <Pagination {...paginationProps} />
+                    </div>
+                  </div>
+                }
+                ariaLabels={{
+                  selectionGroupLabel: 'Items selection',
+                  allItemsSelectionLabel: () => 'select all',
+                  itemSelectionLabel: (data, row) => `select ${row.name}`,
+                }}
+              />
+            </SpaceBetween>
+          </Container>
+        </SpaceBetween>
+      }
+    />
+  );
+}

--- a/src/pages/network-dashboard/root.tsx
+++ b/src/pages/network-dashboard/root.tsx
@@ -212,11 +212,9 @@ export function App() {
                     filterPlaceholder: 'Filter data',
                     legendAriaLabel: 'Legend',
                     chartAriaRoleDescription: 'area chart',
-                    xTickFormatter: (value) => {
-                      const date = new Date(value);
-                      return `x${date.getDate()}`;
-                    },
-                    yTickFormatter: (value) => `y${value}`,
+                    xTickFormatter: (value) =>
+                      value instanceof Date ? `x${value.getDate()}` : String(value),
+                    yTickFormatter: (value) => `y${Number(value).toFixed(0)}`,
                   }}
                   hideFilter
                   hideLegend={false}
@@ -256,8 +254,8 @@ export function App() {
                     filterPlaceholder: 'Filter data',
                     legendAriaLabel: 'Legend',
                     chartAriaRoleDescription: 'bar chart',
-                    xTickFormatter: (value) => value,
-                    yTickFormatter: (value) => `y${value}`,
+                    xTickFormatter: (value) => String(value),
+                    yTickFormatter: (value) => `y${Number(value).toFixed(0)}`,
                   }}
                   hideFilter
                   hideLegend={false}

--- a/src/pages/network-dashboard/root.tsx
+++ b/src/pages/network-dashboard/root.tsx
@@ -171,11 +171,7 @@ export function App() {
       }
       notifications={
         alertVisible ? (
-          <Alert
-            type="error"
-            dismissible
-            onDismiss={() => setAlertVisible(false)}
-          >
+          <Alert type="error" dismissible onDismiss={() => setAlertVisible(false)}>
             This is a warning message
           </Alert>
         ) : null

--- a/src/pages/network-dashboard/root.tsx
+++ b/src/pages/network-dashboard/root.tsx
@@ -147,7 +147,7 @@ export function App() {
   const [devices] = useState(generateDevices());
   const [flashbarItems, setFlashbarItems] = useState([
     {
-      type: 'warning' as const,
+      type: 'error' as const,
       content: 'This is a warning message',
       dismissible: true,
       dismissLabel: 'Dismiss',


### PR DESCRIPTION
### Purpose

Based on the conversation, the goal was to implement a new Network Administration Dashboard from a Figma design. The implementation also involved addressing a runtime error to ensure the page functions correctly.

### Code changes

- **New Page:** A new "Network Dashboard" page has been created and is accessible via the `/network-dashboard` route.
- **Components:** The dashboard is built using `@cloudscape-design/components` and includes:
    - An `AreaChart` to visualize network traffic.
    - A `BarChart` to display credit usage.
    - A `Table` that lists network devices, complete with filtering and pagination.
- **Styling:** Added responsive SCSS styles to ensure the dashboard looks good on various screen sizes.
- **Navigation:** A link to the new dashboard has been added to the main page that lists all available demos.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/82a0d72280b64a4e9c841241494d5ab4/stellar-lab-1)

👀 [Preview Link](https://82a0d72280b64a4e9c841241494d5ab4-stellar-lab-1.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 29`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>82a0d72280b64a4e9c841241494d5ab4</projectId>-->
<!--<branchName>stellar-lab-1</branchName>-->