### PR TITLE
Add network administration dashboard page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -31,6 +31,12 @@ const demos = [
   },
   { route: '/dashboard', title: 'Service Dashboard', description: 'Dashboard layout demo.', category: 'Dashboards' },
   {
+    route: '/network-dashboard',
+    title: 'Network Administration Dashboard',
+    description: 'Network traffic monitoring, credit usage, and device management dashboard.',
+    category: 'Dashboards',
+  },
+  {
     route: '/delete-one-click',
     title: 'One-click Delete',
     description: 'Delete with a single click.',

--- a/src/pages/network-dashboard/app.tsx
+++ b/src/pages/network-dashboard/app.tsx
@@ -14,34 +14,33 @@ import TextFilter from '@cloudscape-design/components/text-filter';
 import Pagination from '@cloudscape-design/components/pagination';
 import Table from '@cloudscape-design/components/table';
 import Flashbar from '@cloudscape-design/components/flashbar';
-import AreaChart from '@cloudscape-design/components/area-chart';
 import BarChart from '@cloudscape-design/components/bar-chart';
 
 import '@cloudscape-design/global-styles/dark-mode-utils.css';
 
-// Sample data for Network Traffic chart
+// Chart data for Network Traffic
 const networkTrafficData = [
-  { x: 'x1', y1: 150, y2: 130 },
-  { x: 'x2', y1: 180, y2: 160 },
-  { x: 'x3', y1: 200, y2: 185 },
-  { x: 'x4', y1: 220, y2: 210 },
-  { x: 'x5', y1: 250, y2: 240 },
-  { x: 'x6', y1: 280, y2: 270 },
-  { x: 'x7', y1: 260, y2: 250 },
-  { x: 'x8', y1: 240, y2: 230 },
-  { x: 'x9', y1: 210, y2: 200 },
-  { x: 'x10', y1: 190, y2: 180 },
-  { x: 'x11', y1: 170, y2: 160 },
-  { x: 'x12', y1: 150, y2: 140 },
+  { x: 'Day 1', y: 150 },
+  { x: 'Day 2', y: 180 },
+  { x: 'Day 3', y: 200 },
+  { x: 'Day 4', y: 220 },
+  { x: 'Day 5', y: 250 },
+  { x: 'Day 6', y: 280 },
+  { x: 'Day 7', y: 260 },
+  { x: 'Day 8', y: 240 },
+  { x: 'Day 9', y: 210 },
+  { x: 'Day 10', y: 190 },
+  { x: 'Day 11', y: 170 },
+  { x: 'Day 12', y: 150 },
 ];
 
-// Sample data for Credit Usage chart
+// Chart data for Credit Usage
 const creditUsageData = [
-  { x: 'x1', y: 183 },
-  { x: 'x2', y: 257 },
-  { x: 'x3', y: 213 },
-  { x: 'x4', y: 122 },
-  { x: 'x5', y: 210 },
+  { x: 'Mon', y: 183 },
+  { x: 'Tue', y: 257 },
+  { x: 'Wed', y: 213 },
+  { x: 'Thu', y: 122 },
+  { x: 'Fri', y: 210 },
 ];
 
 // Sample data for devices table
@@ -153,10 +152,7 @@ export function App() {
                     type: 'warning',
                     content: 'This is a warning message',
                     dismissible: true,
-                    dismissLabel: 'Dismiss',
                     onDismiss: () => setShowWarning(false),
-                    buttonText: 'Dismiss',
-                    onButtonClick: () => setShowWarning(false),
                   },
                 ]}
               />
@@ -164,104 +160,52 @@ export function App() {
 
             <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
               <Container>
-                <Box variant="h2" padding={{ bottom: 's' }}>
-                  Network traffic
-                </Box>
-                <AreaChart
-                  series={[
-                    {
-                      title: 'Site 1',
-                      type: 'area',
-                      data: networkTrafficData.map(d => ({ x: d.x, y: d.y1 })),
-                      valueFormatter: (value) => `${value}`,
-                    },
-                    {
-                      title: 'Site 2',
-                      type: 'area',
-                      data: networkTrafficData.map(d => ({ x: d.x, y: d.y2 })),
-                      valueFormatter: (value) => `${value}`,
-                    },
-                  ]}
-                  xDomain={networkTrafficData.map(d => d.x)}
-                  yDomain={[0, 300]}
-                  i18nStrings={{
-                    filterLabel: 'Filter displayed data',
-                    filterPlaceholder: 'Filter data',
-                    filterSelectedAriaLabel: 'selected',
-                    legendAriaLabel: 'Legend',
-                    chartAriaRoleDescription: 'area chart',
-                    xAxisAriaRoleDescription: 'x axis',
-                    yAxisAriaRoleDescription: 'y axis',
-                  }}
-                  ariaLabel="Network traffic area chart"
-                  height={300}
-                  xScaleType="categorical"
-                  xTitle="Day"
-                  yTitle=""
-                  empty={
-                    <Box textAlign="center" color="inherit">
-                      <b>No data available</b>
-                      <Box variant="p" color="inherit">
-                        There is no data available
-                      </Box>
-                    </Box>
-                  }
-                  noMatch={
-                    <Box textAlign="center" color="inherit">
-                      <b>No matching data</b>
-                      <Box variant="p" color="inherit">
-                        There is no matching data to display
-                      </Box>
-                    </Box>
-                  }
-                />
-              </Container>
-
-              <Container>
-                <Box variant="h2" padding={{ bottom: 's' }}>
-                  Credit Usage
-                </Box>
+                <Header variant="h2" description="Daily network traffic">
+                  Network Traffic
+                </Header>
                 <BarChart
                   series={[
                     {
                       title: 'Site 1',
                       type: 'bar',
+                      data: networkTrafficData,
+                    },
+                  ]}
+                  xDomain={networkTrafficData.map(d => d.x)}
+                  yDomain={[0, 300]}
+                  hideFilter={true}
+                  hideLegend={true}
+                  fitHeight={true}
+                  height={20}
+                  xScaleType="categorical"
+                  xTitle="Day"
+                  yTitle=""
+                  ariaLabel="Network traffic bar chart"
+                />
+              </Container>
+
+              <Container>
+                <Header variant="h2" description="Daily credit usage">
+                  Credit Usage
+                </Header>
+                <BarChart
+                  series={[
+                    {
+                      title: 'Credits Used',
+                      type: 'bar',
                       data: creditUsageData,
-                      valueFormatter: (value) => `${value}`,
                     },
                   ]}
                   xDomain={creditUsageData.map(d => d.x)}
                   yDomain={[0, 300]}
-                  i18nStrings={{
-                    filterLabel: 'Filter displayed data',
-                    filterPlaceholder: 'Filter data',
-                    filterSelectedAriaLabel: 'selected',
-                    legendAriaLabel: 'Legend',
-                    chartAriaRoleDescription: 'bar chart',
-                    xAxisAriaRoleDescription: 'x axis',
-                    yAxisAriaRoleDescription: 'y axis',
-                  }}
-                  ariaLabel="Credit usage bar chart"
-                  height={300}
+                  hideFilter={true}
+                  hideLegend={true}
+                  fitHeight={true}
+                  height={20}
                   xScaleType="categorical"
                   xTitle="Day"
                   yTitle=""
-                  empty={
-                    <Box textAlign="center" color="inherit">
-                      <b>No data available</b>
-                      <Box variant="p" color="inherit">
-                        There is no data available
-                      </Box>
-                    </Box>
-                  }
-                  noMatch={
-                    <Box textAlign="center" color="inherit">
-                      <b>No matching data</b>
-                      <Box variant="p" color="inherit">
-                        There is no matching data to display
-                      </Box>
-                    </Box>
-                  }
+                  ariaLabel="Credit usage bar chart"
                 />
               </Container>
             </Grid>
@@ -294,7 +238,7 @@ export function App() {
                 <Grid gridDefinition={[{ colspan: { default: 12, s: 6 } }, { colspan: { default: 12, s: 6 } }]}>
                   <TextFilter
                     filteringText={filterText}
-                    filteringPlaceholder="Placeholder"
+                    filteringPlaceholder="Find devices"
                     filteringAriaLabel="Filter devices"
                     onChange={({ detail }) => {
                       setFilterText(detail.filteringText);

--- a/src/pages/network-dashboard/app.tsx
+++ b/src/pages/network-dashboard/app.tsx
@@ -139,7 +139,7 @@ export function App() {
                   </Button>
                 }
               >
-                Network Administration Dashboard
+                Network Admin Dashboard
               </Header>
             </SpaceBetween>
           }
@@ -149,7 +149,7 @@ export function App() {
               <Flashbar
                 items={[
                   {
-                    type: 'warning',
+                    type: 'error',
                     content: 'This is a warning message',
                     dismissible: true,
                     onDismiss: () => setShowWarning(false),

--- a/src/pages/network-dashboard/app.tsx
+++ b/src/pages/network-dashboard/app.tsx
@@ -1,0 +1,347 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState } from 'react';
+import AppLayout from '@cloudscape-design/components/app-layout';
+import ContentLayout from '@cloudscape-design/components/content-layout';
+import BreadcrumbGroup from '@cloudscape-design/components/breadcrumb-group';
+import Header from '@cloudscape-design/components/header';
+import Button from '@cloudscape-design/components/button';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Grid from '@cloudscape-design/components/grid';
+import Container from '@cloudscape-design/components/container';
+import Box from '@cloudscape-design/components/box';
+import TextFilter from '@cloudscape-design/components/text-filter';
+import Pagination from '@cloudscape-design/components/pagination';
+import Table from '@cloudscape-design/components/table';
+import Flashbar from '@cloudscape-design/components/flashbar';
+import AreaChart from '@cloudscape-design/components/area-chart';
+import BarChart from '@cloudscape-design/components/bar-chart';
+
+import '@cloudscape-design/global-styles/dark-mode-utils.css';
+
+// Sample data for Network Traffic chart
+const networkTrafficData = [
+  { x: 'x1', y1: 150, y2: 130 },
+  { x: 'x2', y1: 180, y2: 160 },
+  { x: 'x3', y1: 200, y2: 185 },
+  { x: 'x4', y1: 220, y2: 210 },
+  { x: 'x5', y1: 250, y2: 240 },
+  { x: 'x6', y1: 280, y2: 270 },
+  { x: 'x7', y1: 260, y2: 250 },
+  { x: 'x8', y1: 240, y2: 230 },
+  { x: 'x9', y1: 210, y2: 200 },
+  { x: 'x10', y1: 190, y2: 180 },
+  { x: 'x11', y1: 170, y2: 160 },
+  { x: 'x12', y1: 150, y2: 140 },
+];
+
+// Sample data for Credit Usage chart
+const creditUsageData = [
+  { x: 'x1', y: 183 },
+  { x: 'x2', y: 257 },
+  { x: 'x3', y: 213 },
+  { x: 'x4', y: 122 },
+  { x: 'x5', y: 210 },
+];
+
+// Sample data for devices table
+const devicesData = Array.from({ length: 12 }, (_, i) => ({
+  id: `device-${i + 1}`,
+  name: `Device ${i + 1}`,
+  ipAddress: `192.168.1.${i + 10}`,
+  macAddress: `00:1B:44:11:3A:${(i + 10).toString(16).toUpperCase().padStart(2, '0')}`,
+  status: i % 3 === 0 ? 'Active' : i % 3 === 1 ? 'Inactive' : 'Pending',
+  type: i % 2 === 0 ? 'Router' : 'Switch',
+  location: `Floor ${Math.floor(i / 3) + 1}`,
+  lastSeen: `${i + 1} hours ago`,
+}));
+
+const columnDefinitions = [
+  {
+    id: 'name',
+    header: 'Device Name',
+    cell: (item: typeof devicesData[0]) => item.name,
+    sortingField: 'name',
+  },
+  {
+    id: 'ipAddress',
+    header: 'IP Address',
+    cell: (item: typeof devicesData[0]) => item.ipAddress,
+    sortingField: 'ipAddress',
+  },
+  {
+    id: 'macAddress',
+    header: 'MAC Address',
+    cell: (item: typeof devicesData[0]) => item.macAddress,
+    sortingField: 'macAddress',
+  },
+  {
+    id: 'status',
+    header: 'Status',
+    cell: (item: typeof devicesData[0]) => item.status,
+    sortingField: 'status',
+  },
+  {
+    id: 'type',
+    header: 'Type',
+    cell: (item: typeof devicesData[0]) => item.type,
+    sortingField: 'type',
+  },
+  {
+    id: 'location',
+    header: 'Location',
+    cell: (item: typeof devicesData[0]) => item.location,
+    sortingField: 'location',
+  },
+  {
+    id: 'lastSeen',
+    header: 'Last Seen',
+    cell: (item: typeof devicesData[0]) => item.lastSeen,
+    sortingField: 'lastSeen',
+  },
+];
+
+export function App() {
+  const [filterText, setFilterText] = useState('');
+  const [selectedItems, setSelectedItems] = useState<typeof devicesData>([]);
+  const [currentPageIndex, setCurrentPageIndex] = useState(1);
+  const [showWarning, setShowWarning] = useState(true);
+  const itemsPerPage = 5;
+
+  const filteredDevices = devicesData.filter(device =>
+    device.name.toLowerCase().includes(filterText.toLowerCase())
+  );
+
+  const paginatedDevices = filteredDevices.slice(
+    (currentPageIndex - 1) * itemsPerPage,
+    currentPageIndex * itemsPerPage
+  );
+
+  return (
+    <AppLayout
+      navigationHide
+      toolsHide
+      content={
+        <ContentLayout
+          header={
+            <SpaceBetween size="m">
+              <BreadcrumbGroup
+                items={[
+                  { text: 'Service', href: '#' },
+                  { text: 'Administrative Dashboard', href: '#' },
+                ]}
+              />
+              <Header
+                variant="h1"
+                description="Network Traffic, Credit Usage, and Your Devices"
+                actions={
+                  <Button variant="primary" iconAlign="right" iconName="external">
+                    Refresh Data
+                  </Button>
+                }
+              >
+                Network Administration Dashboard
+              </Header>
+            </SpaceBetween>
+          }
+        >
+          <SpaceBetween size="l">
+            {showWarning && (
+              <Flashbar
+                items={[
+                  {
+                    type: 'warning',
+                    content: 'This is a warning message',
+                    dismissible: true,
+                    dismissLabel: 'Dismiss',
+                    onDismiss: () => setShowWarning(false),
+                    buttonText: 'Dismiss',
+                    onButtonClick: () => setShowWarning(false),
+                  },
+                ]}
+              />
+            )}
+
+            <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+              <Container>
+                <Box variant="h2" padding={{ bottom: 's' }}>
+                  Network traffic
+                </Box>
+                <AreaChart
+                  series={[
+                    {
+                      title: 'Site 1',
+                      type: 'area',
+                      data: networkTrafficData.map(d => ({ x: d.x, y: d.y1 })),
+                      valueFormatter: (value) => `${value}`,
+                    },
+                    {
+                      title: 'Site 2',
+                      type: 'area',
+                      data: networkTrafficData.map(d => ({ x: d.x, y: d.y2 })),
+                      valueFormatter: (value) => `${value}`,
+                    },
+                  ]}
+                  xDomain={networkTrafficData.map(d => d.x)}
+                  yDomain={[0, 300]}
+                  i18nStrings={{
+                    filterLabel: 'Filter displayed data',
+                    filterPlaceholder: 'Filter data',
+                    filterSelectedAriaLabel: 'selected',
+                    legendAriaLabel: 'Legend',
+                    chartAriaRoleDescription: 'area chart',
+                    xAxisAriaRoleDescription: 'x axis',
+                    yAxisAriaRoleDescription: 'y axis',
+                  }}
+                  ariaLabel="Network traffic area chart"
+                  height={300}
+                  xScaleType="categorical"
+                  xTitle="Day"
+                  yTitle=""
+                  empty={
+                    <Box textAlign="center" color="inherit">
+                      <b>No data available</b>
+                      <Box variant="p" color="inherit">
+                        There is no data available
+                      </Box>
+                    </Box>
+                  }
+                  noMatch={
+                    <Box textAlign="center" color="inherit">
+                      <b>No matching data</b>
+                      <Box variant="p" color="inherit">
+                        There is no matching data to display
+                      </Box>
+                    </Box>
+                  }
+                />
+              </Container>
+
+              <Container>
+                <Box variant="h2" padding={{ bottom: 's' }}>
+                  Credit Usage
+                </Box>
+                <BarChart
+                  series={[
+                    {
+                      title: 'Site 1',
+                      type: 'bar',
+                      data: creditUsageData,
+                      valueFormatter: (value) => `${value}`,
+                    },
+                  ]}
+                  xDomain={creditUsageData.map(d => d.x)}
+                  yDomain={[0, 300]}
+                  i18nStrings={{
+                    filterLabel: 'Filter displayed data',
+                    filterPlaceholder: 'Filter data',
+                    filterSelectedAriaLabel: 'selected',
+                    legendAriaLabel: 'Legend',
+                    chartAriaRoleDescription: 'bar chart',
+                    xAxisAriaRoleDescription: 'x axis',
+                    yAxisAriaRoleDescription: 'y axis',
+                  }}
+                  ariaLabel="Credit usage bar chart"
+                  height={300}
+                  xScaleType="categorical"
+                  xTitle="Day"
+                  yTitle=""
+                  empty={
+                    <Box textAlign="center" color="inherit">
+                      <b>No data available</b>
+                      <Box variant="p" color="inherit">
+                        There is no data available
+                      </Box>
+                    </Box>
+                  }
+                  noMatch={
+                    <Box textAlign="center" color="inherit">
+                      <b>No matching data</b>
+                      <Box variant="p" color="inherit">
+                        There is no matching data to display
+                      </Box>
+                    </Box>
+                  }
+                />
+              </Container>
+            </Grid>
+
+            <Table
+              columnDefinitions={columnDefinitions}
+              items={paginatedDevices}
+              selectionType="multi"
+              selectedItems={selectedItems}
+              onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
+              ariaLabels={{
+                selectionGroupLabel: 'Items selection',
+                allItemsSelectionLabel: () => 'select all',
+                itemSelectionLabel: (_, item) => item.name,
+              }}
+              header={
+                <Header
+                  variant="h2"
+                  description="Devices on your local network"
+                  actions={
+                    <Button variant="primary" iconAlign="right" iconName="external">
+                      Add Device
+                    </Button>
+                  }
+                >
+                  My Devices
+                </Header>
+              }
+              filter={
+                <Grid gridDefinition={[{ colspan: { default: 12, s: 6 } }, { colspan: { default: 12, s: 6 } }]}>
+                  <TextFilter
+                    filteringText={filterText}
+                    filteringPlaceholder="Placeholder"
+                    filteringAriaLabel="Filter devices"
+                    onChange={({ detail }) => {
+                      setFilterText(detail.filteringText);
+                      setCurrentPageIndex(1);
+                    }}
+                  />
+                  <Box float="right">
+                    <SpaceBetween direction="horizontal" size="xs">
+                      <Pagination
+                        currentPageIndex={currentPageIndex}
+                        onChange={({ detail }) => setCurrentPageIndex(detail.currentPageIndex)}
+                        pagesCount={Math.ceil(filteredDevices.length / itemsPerPage)}
+                        ariaLabels={{
+                          nextPageLabel: 'Next page',
+                          previousPageLabel: 'Previous page',
+                          pageLabel: pageNumber => `Page ${pageNumber}`,
+                        }}
+                      />
+                      <Button iconName="settings" variant="icon" />
+                    </SpaceBetween>
+                  </Box>
+                </Grid>
+              }
+              pagination={
+                <Pagination
+                  currentPageIndex={currentPageIndex}
+                  onChange={({ detail }) => setCurrentPageIndex(detail.currentPageIndex)}
+                  pagesCount={Math.ceil(filteredDevices.length / itemsPerPage)}
+                  ariaLabels={{
+                    nextPageLabel: 'Next page',
+                    previousPageLabel: 'Previous page',
+                    pageLabel: pageNumber => `Page ${pageNumber}`,
+                  }}
+                />
+              }
+              empty={
+                <Box textAlign="center" color="inherit">
+                  <Box padding={{ bottom: 's' }} variant="p" color="inherit">
+                    <b>No devices</b>
+                  </Box>
+                  <Button>Add device</Button>
+                </Box>
+              }
+            />
+          </SpaceBetween>
+        </ContentLayout>
+      }
+    />
+  );
+}

--- a/src/pages/network-dashboard/app.tsx
+++ b/src/pages/network-dashboard/app.tsx
@@ -59,43 +59,43 @@ const columnDefinitions = [
   {
     id: 'name',
     header: 'Device Name',
-    cell: (item: typeof devicesData[0]) => item.name,
+    cell: (item: (typeof devicesData)[0]) => item.name,
     sortingField: 'name',
   },
   {
     id: 'ipAddress',
     header: 'IP Address',
-    cell: (item: typeof devicesData[0]) => item.ipAddress,
+    cell: (item: (typeof devicesData)[0]) => item.ipAddress,
     sortingField: 'ipAddress',
   },
   {
     id: 'macAddress',
     header: 'MAC Address',
-    cell: (item: typeof devicesData[0]) => item.macAddress,
+    cell: (item: (typeof devicesData)[0]) => item.macAddress,
     sortingField: 'macAddress',
   },
   {
     id: 'status',
     header: 'Status',
-    cell: (item: typeof devicesData[0]) => item.status,
+    cell: (item: (typeof devicesData)[0]) => item.status,
     sortingField: 'status',
   },
   {
     id: 'type',
     header: 'Type',
-    cell: (item: typeof devicesData[0]) => item.type,
+    cell: (item: (typeof devicesData)[0]) => item.type,
     sortingField: 'type',
   },
   {
     id: 'location',
     header: 'Location',
-    cell: (item: typeof devicesData[0]) => item.location,
+    cell: (item: (typeof devicesData)[0]) => item.location,
     sortingField: 'location',
   },
   {
     id: 'lastSeen',
     header: 'Last Seen',
-    cell: (item: typeof devicesData[0]) => item.lastSeen,
+    cell: (item: (typeof devicesData)[0]) => item.lastSeen,
     sortingField: 'lastSeen',
   },
 ];
@@ -107,13 +107,11 @@ export function App() {
   const [showWarning, setShowWarning] = useState(true);
   const itemsPerPage = 5;
 
-  const filteredDevices = devicesData.filter(device =>
-    device.name.toLowerCase().includes(filterText.toLowerCase())
-  );
+  const filteredDevices = devicesData.filter(device => device.name.toLowerCase().includes(filterText.toLowerCase()));
 
   const paginatedDevices = filteredDevices.slice(
     (currentPageIndex - 1) * itemsPerPage,
-    currentPageIndex * itemsPerPage
+    currentPageIndex * itemsPerPage,
   );
 
   return (

--- a/src/pages/network-dashboard/index.tsx
+++ b/src/pages/network-dashboard/index.tsx
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import { App } from './app';
+
+import '../../styles/base.scss';
+
+export default function NetworkDashboardDemo() {
+  return <App />;
+}


### PR DESCRIPTION
## Purpose
Implement a responsive Network Administration Dashboard to visualize network traffic, credit usage, and manage devices, ensuring the layout is fluid and functional across different screen sizes.

## Code changes
- **`src/pages/index.tsx`**: Added the `/network-dashboard` route to the demos list.
- **`src/pages/network-dashboard/app.tsx`**: Created the main dashboard component using Cloudscape components, featuring:
  - Two `BarChart` components for "Network Traffic" and "Credit Usage".
  - A `Table` component for "My Devices" with sortable columns, pagination, and text filtering.
  - Responsive layout using `AppLayout`, `ContentLayout`, and `Grid`.
- **`src/pages/network-dashboard/index.tsx`**: Added the entry point for the new dashboard page.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/82a0d72280b64a4e9c841241494d5ab4/zenith-den)

👀 [Preview Link](https://82a0d72280b64a4e9c841241494d5ab4-zenith-den.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 32`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>82a0d72280b64a4e9c841241494d5ab4</projectId>-->
<!--<branchName>zenith-den</branchName>-->