### PR TITLE
Add Network Administration Dashboard page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -128,6 +128,12 @@ const demos = [
   },
   { route: '/wizard', title: 'Wizard', description: 'Multi-step wizard demo.', category: 'Forms' },
   { route: '/write-to-s3', title: 'Write to S3', description: 'Write data to Amazon S3.', category: 'Integration' },
+  {
+    route: '/network-dashboard',
+    title: 'Network Administration Dashboard',
+    description: 'Network traffic, credit usage, and device management dashboard.',
+    category: 'Dashboards',
+  },
 ];
 
 // Get unique categories

--- a/src/pages/network-dashboard/index.tsx
+++ b/src/pages/network-dashboard/index.tsx
@@ -1,0 +1,324 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState } from 'react';
+
+import '../../styles/network-dashboard.scss';
+
+import Alert from '@cloudscape-design/components/alert';
+import AppLayout from '@cloudscape-design/components/app-layout';
+import AreaChart from '@cloudscape-design/components/area-chart';
+import BarChart from '@cloudscape-design/components/bar-chart';
+import Box from '@cloudscape-design/components/box';
+import BreadcrumbGroup from '@cloudscape-design/components/breadcrumb-group';
+import Button from '@cloudscape-design/components/button';
+import ColumnLayout from '@cloudscape-design/components/column-layout';
+import Container from '@cloudscape-design/components/container';
+import ContentLayout from '@cloudscape-design/components/content-layout';
+import Header from '@cloudscape-design/components/header';
+import { I18nProvider } from '@cloudscape-design/components/i18n';
+import enMessages from '@cloudscape-design/components/i18n/messages/all.en.json';
+import Pagination from '@cloudscape-design/components/pagination';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Table from '@cloudscape-design/components/table';
+import TextFilter from '@cloudscape-design/components/text-filter';
+
+// ── Data ──────────────────────────────────────────────────────────────────────
+
+const networkTrafficSite1 = [
+  { x: 1, y: 2.5 },
+  { x: 2, y: 2.8 },
+  { x: 3, y: 3.0 },
+  { x: 4, y: 3.5 },
+  { x: 5, y: 3.2 },
+  { x: 6, y: 3.8 },
+  { x: 7, y: 4.0 },
+  { x: 8, y: 4.2 },
+  { x: 9, y: 4.5 },
+  { x: 10, y: 4.3 },
+  { x: 11, y: 4.8 },
+  { x: 12, y: 4.6 },
+];
+
+const networkTrafficSite2 = [
+  { x: 1, y: 3.2 },
+  { x: 2, y: 3.0 },
+  { x: 3, y: 3.5 },
+  { x: 4, y: 4.5 },
+  { x: 5, y: 4.2 },
+  { x: 6, y: 4.8 },
+  { x: 7, y: 5.2 },
+  { x: 8, y: 5.0 },
+  { x: 9, y: 5.5 },
+  { x: 10, y: 5.3 },
+  { x: 11, y: 5.0 },
+  { x: 12, y: 5.4 },
+];
+
+const creditUsageData = [
+  { x: 'x1', y: 4.2 },
+  { x: 'x2', y: 5.8 },
+  { x: 'x3', y: 5.0 },
+  { x: 'x4', y: 3.2 },
+  { x: 'x5', y: 4.8 },
+];
+
+// ── Placeholder device rows ────────────────────────────────────────────────────
+
+const generateDeviceRows = (count: number) =>
+  Array.from({ length: count }, (_, i) => ({
+    id: `device-${i + 1}`,
+    col1: 'Cell Value',
+    col2: 'Cell Value',
+    col3: 'Cell Value',
+    col4: 'Cell Value',
+    col5: 'Cell Value',
+    col6: 'Cell Value',
+    col7: 'Cell Value',
+  }));
+
+const deviceRows = generateDeviceRows(13);
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export default function NetworkDashboard() {
+  const [warningVisible, setWarningVisible] = useState(true);
+  const [filterText, setFilterText] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const [selectedDevices, setSelectedDevices] = useState<typeof deviceRows>([]);
+
+  return (
+    <I18nProvider locale="en" messages={[enMessages]}>
+      <AppLayout
+        navigationHide
+        toolsHide
+        breadcrumbs={
+          <BreadcrumbGroup
+            items={[
+              { text: 'Service', href: '#' },
+              { text: 'Administrative Dashboard', href: '#' },
+            ]}
+            ariaLabel="Breadcrumbs"
+          />
+        }
+        notifications={
+          warningVisible ? (
+            <Alert
+              type="warning"
+              dismissible
+              onDismiss={() => setWarningVisible(false)}
+            >
+              This is a warning message
+            </Alert>
+          ) : undefined
+        }
+        content={
+          <ContentLayout
+            header={
+              <Header
+                variant="h1"
+                description="Network Traffic, Credit Usage, and Your Devices"
+                actions={
+                  <Button variant="primary" iconAlign="right" iconName="external">
+                    Refresh Data
+                  </Button>
+                }
+              >
+                Network Adminstration Dashboard
+              </Header>
+            }
+          >
+            <SpaceBetween size="l">
+              {/* Search + Pagination row */}
+              <div className="dashboard-filter-row">
+                <div className="dashboard-filter-search">
+                  <TextFilter
+                    filteringText={filterText}
+                    filteringPlaceholder="Placeholder"
+                    filteringAriaLabel="Filter devices"
+                    onChange={({ detail }) => setFilterText(detail.filteringText)}
+                  />
+                </div>
+                <div className="dashboard-filter-pagination">
+                  <Pagination
+                    currentPageIndex={currentPage}
+                    pagesCount={5}
+                    onChange={({ detail }) => setCurrentPage(detail.currentPageIndex)}
+                    ariaLabels={{
+                      nextPageLabel: 'Next page',
+                      previousPageLabel: 'Previous page',
+                      pageLabel: n => `Page ${n} of 5`,
+                    }}
+                  />
+                </div>
+              </div>
+
+              {/* Charts row */}
+              <ColumnLayout columns={2} variant="default">
+                {/* Network Traffic – Area Chart */}
+                <Container header={<Header variant="h2">Network traffic</Header>}>
+                  <AreaChart
+                    series={[
+                      {
+                        title: 'Site 1',
+                        type: 'area',
+                        data: networkTrafficSite1,
+                        color: '#688AE8',
+                      },
+                      {
+                        title: 'Site 2',
+                        type: 'area',
+                        data: networkTrafficSite2,
+                        color: '#C33D69',
+                      },
+                      {
+                        title: 'Performance goal',
+                        type: 'threshold',
+                        y: 3.5,
+                        color: '#5F6B7A',
+                      },
+                    ]}
+                    xDomain={[1, 12]}
+                    yDomain={[0, 6]}
+                    xTitle="Day"
+                    xScaleType="linear"
+                    height={300}
+                    hideFilter
+                    ariaLabel="Network traffic chart"
+                    i18nStrings={{
+                      xTickFormatter: v => `x${v}`,
+                      yTickFormatter: v => `y${v}`,
+                      filterLabel: 'Filter displayed data',
+                      filterPlaceholder: 'Filter data',
+                      filterSelectedAriaLabel: 'selected',
+                      legendAriaLabel: 'Legend',
+                      chartAriaRoleDescription: 'area chart',
+                      xAxisAriaRoleDescription: 'x axis',
+                      yAxisAriaRoleDescription: 'y axis',
+                    }}
+                  />
+                </Container>
+
+                {/* Credit Usage – Bar Chart */}
+                <Container header={<Header variant="h2">Credit Usage</Header>}>
+                  <BarChart
+                    series={[
+                      {
+                        title: 'Site 1',
+                        type: 'bar',
+                        data: creditUsageData,
+                        color: '#688AE8',
+                      },
+                      {
+                        title: 'Performance goal',
+                        type: 'threshold',
+                        y: 3.5,
+                        color: '#5F6B7A',
+                      },
+                    ]}
+                    xDomain={['x1', 'x2', 'x3', 'x4', 'x5']}
+                    yDomain={[0, 6]}
+                    xTitle="Day"
+                    height={300}
+                    hideFilter
+                    ariaLabel="Credit usage chart"
+                    i18nStrings={{
+                      yTickFormatter: v => `y${v}`,
+                      filterLabel: 'Filter displayed data',
+                      filterPlaceholder: 'Filter data',
+                      filterSelectedAriaLabel: 'selected',
+                      legendAriaLabel: 'Legend',
+                      chartAriaRoleDescription: 'bar chart',
+                      xAxisAriaRoleDescription: 'x axis',
+                      yAxisAriaRoleDescription: 'y axis',
+                    }}
+                  />
+                </Container>
+              </ColumnLayout>
+
+              {/* My Devices table */}
+              <Table
+                header={
+                  <Header
+                    variant="h2"
+                    description="Devices on your local network"
+                    actions={
+                      <Button variant="primary" iconAlign="right" iconName="external">
+                        Add Device
+                      </Button>
+                    }
+                  >
+                    My Devices
+                  </Header>
+                }
+                columnDefinitions={[
+                  {
+                    id: 'col1',
+                    header: 'Column header',
+                    cell: item => item.col1,
+                    sortingField: 'col1',
+                  },
+                  {
+                    id: 'col2',
+                    header: 'Column header',
+                    cell: item => item.col2,
+                    sortingField: 'col2',
+                  },
+                  {
+                    id: 'col3',
+                    header: 'Column header',
+                    cell: item => item.col3,
+                    sortingField: 'col3',
+                  },
+                  {
+                    id: 'col4',
+                    header: 'Column header',
+                    cell: item => item.col4,
+                    sortingField: 'col4',
+                  },
+                  {
+                    id: 'col5',
+                    header: 'Column header',
+                    cell: item => item.col5,
+                    sortingField: 'col5',
+                  },
+                  {
+                    id: 'col6',
+                    header: 'Column header',
+                    cell: item => item.col6,
+                    sortingField: 'col6',
+                  },
+                  {
+                    id: 'col7',
+                    header: 'Column header',
+                    cell: item => item.col7,
+                    sortingField: 'col7',
+                  },
+                ]}
+                items={deviceRows}
+                selectionType="multi"
+                selectedItems={selectedDevices}
+                onSelectionChange={({ detail }) => setSelectedDevices(detail.selectedItems)}
+                trackBy="id"
+                sortingDisabled={false}
+                variant="container"
+                ariaLabels={{
+                  selectionGroupLabel: 'Device selection',
+                  allItemsSelectionLabel: () => 'select all',
+                  itemSelectionLabel: (_, item) => `select ${item.id}`,
+                }}
+                empty={
+                  <Box textAlign="center" color="inherit">
+                    <b>No devices</b>
+                    <Box variant="p" color="inherit">
+                      No devices found on your local network.
+                    </Box>
+                  </Box>
+                }
+              />
+            </SpaceBetween>
+          </ContentLayout>
+        }
+      />
+    </I18nProvider>
+  );
+}

--- a/src/styles/network-dashboard.scss
+++ b/src/styles/network-dashboard.scss
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+.dashboard-filter-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.dashboard-filter-search {
+  flex: 1;
+  max-width: 800px;
+}
+
+.dashboard-filter-pagination {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}


### PR DESCRIPTION
### Summary
Adds a new Network Administration Dashboard page built from a Figma design, featuring network traffic and credit usage charts alongside a device management table.

### Problem
There was no network administration dashboard in the demo application to visualize network traffic, credit usage, and connected device management in a single view.

### Key Changes
- **New page** at `/network-dashboard` (`src/pages/network-dashboard/index.tsx`) using Cloudscape `AppLayout` with breadcrumbs and a dismissible warning notification
- **Network Traffic Area Chart** displaying two site series and a performance goal threshold line
- **Credit Usage Bar Chart** with a bar series and a performance goal threshold line
- **My Devices Table** with multi-select, sortable columns, pagination, and a text filter row
- **Responsive filter row** (`dashboard-filter-row`) using flexbox so the search input and pagination sit side-by-side and adapt to all screen sizes (`src/styles/network-dashboard.scss`)
- **Demo index entry** added to `src/pages/index.tsx` under the `Dashboards` category so the new page is discoverable from the main demo listing


---

<a href="https://builder.io/app/projects/82a0d72280b64a4e9c841241494d5ab4/broad-sound-bbl79ndh"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://82a0d72280b64a4e9c841241494d5ab4-broad-sound-bbl79ndh_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 41`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>82a0d72280b64a4e9c841241494d5ab4</projectId>-->
<!--<branchName>broad-sound-bbl79ndh</branchName>-->