### PR TITLE
Add Network Administration Dashboard page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,6 +21,12 @@ import Link from '@cloudscape-design/components/link';
 
 // Demo definitions with category information
 const demos = [
+  {
+    route: '/network-dashboard',
+    title: 'Network Administration Dashboard',
+    description: 'Network traffic, credit usage, and device management dashboard.',
+    category: 'Dashboards',
+  },
   { route: '/cards', title: 'Card View', description: 'Demo of Cloudscape Cards component.', category: 'Components' },
   { route: '/chat', title: 'Chat', description: 'Chat UI demo.', category: 'Applications' },
   {

--- a/src/pages/network-dashboard/index.tsx
+++ b/src/pages/network-dashboard/index.tsx
@@ -9,7 +9,7 @@ import Button from '@cloudscape-design/components/button';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import TextFilter from '@cloudscape-design/components/text-filter';
 import Pagination from '@cloudscape-design/components/pagination';
-import Flashbar from '@cloudscape-design/components/flashbar';
+import Alert from '@cloudscape-design/components/alert';
 import Grid from '@cloudscape-design/components/grid';
 import Container from '@cloudscape-design/components/container';
 import Box from '@cloudscape-design/components/box';
@@ -155,17 +155,13 @@ export default function NetworkDashboard() {
               </SpaceBetween>
 
               {warningVisible && (
-                <Flashbar
-                  items={[
-                    {
-                      type: 'error',
-                      content: 'This is a warning message',
-                      dismissible: true,
-                      onDismiss: () => setWarningVisible(false),
-                      id: 'network-warning',
-                    },
-                  ]}
-                />
+                <Alert
+                  type="error"
+                  dismissible
+                  onDismiss={() => setWarningVisible(false)}
+                >
+                  This is a warning message
+                </Alert>
               )}
             </SpaceBetween>
           }

--- a/src/pages/network-dashboard/index.tsx
+++ b/src/pages/network-dashboard/index.tsx
@@ -1,0 +1,366 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React, { useState } from 'react';
+import AppLayout from '@cloudscape-design/components/app-layout';
+import BreadcrumbGroup from '@cloudscape-design/components/breadcrumb-group';
+import Header from '@cloudscape-design/components/header';
+import Button from '@cloudscape-design/components/button';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import TextFilter from '@cloudscape-design/components/text-filter';
+import Pagination from '@cloudscape-design/components/pagination';
+import Flashbar from '@cloudscape-design/components/flashbar';
+import Grid from '@cloudscape-design/components/grid';
+import Container from '@cloudscape-design/components/container';
+import Box from '@cloudscape-design/components/box';
+import AreaChart from '@cloudscape-design/components/area-chart';
+import BarChart from '@cloudscape-design/components/bar-chart';
+import Table from '@cloudscape-design/components/table';
+import ContentLayout from '@cloudscape-design/components/content-layout';
+
+import '../../styles/base.scss';
+
+const networkTrafficData = {
+  site1: [
+    { x: 'x1', y: 2.8 },
+    { x: 'x2', y: 3.2 },
+    { x: 'x3', y: 3.8 },
+    { x: 'x4', y: 4.0 },
+    { x: 'x5', y: 3.5 },
+    { x: 'x6', y: 3.9 },
+    { x: 'x7', y: 4.1 },
+    { x: 'x8', y: 4.3 },
+    { x: 'x9', y: 4.5 },
+    { x: 'x10', y: 4.2 },
+    { x: 'x11', y: 4.0 },
+    { x: 'x12', y: 3.8 },
+  ],
+  site2: [
+    { x: 'x1', y: 3.5 },
+    { x: 'x2', y: 3.0 },
+    { x: 'x3', y: 4.2 },
+    { x: 'x4', y: 4.8 },
+    { x: 'x5', y: 5.0 },
+    { x: 'x6', y: 4.6 },
+    { x: 'x7', y: 4.8 },
+    { x: 'x8', y: 5.1 },
+    { x: 'x9', y: 5.2 },
+    { x: 'x10', y: 4.9 },
+    { x: 'x11', y: 4.7 },
+    { x: 'x12', y: 4.5 },
+  ],
+};
+
+const creditUsageData = [
+  { x: 'x1', y: 4.2 },
+  { x: 'x2', y: 5.8 },
+  { x: 'x3', y: 4.9 },
+  { x: 'x4', y: 3.3 },
+  { x: 'x5', y: 5.0 },
+];
+
+interface Device {
+  id: string;
+  name: string;
+  type: string;
+  ipAddress: string;
+  status: string;
+  lastSeen: string;
+  bandwidth: string;
+  location: string;
+}
+
+const allDevices: Device[] = Array.from({ length: 50 }, (_, i) => ({
+  id: `device-${i + 1}`,
+  name: `Device-${String(i + 1).padStart(3, '0')}`,
+  type: ['Router', 'Switch', 'Access Point', 'Server', 'Workstation'][i % 5],
+  ipAddress: `192.168.${Math.floor(i / 254) + 1}.${(i % 254) + 1}`,
+  status: ['Active', 'Idle', 'Offline'][i % 3],
+  lastSeen: `${Math.floor(Math.random() * 60) + 1}m ago`,
+  bandwidth: `${(Math.random() * 100).toFixed(1)} Mbps`,
+  location: ['Floor 1', 'Floor 2', 'Floor 3', 'Data Center', 'Remote'][i % 5],
+}));
+
+const DEVICES_PER_PAGE = 12;
+
+export default function NetworkDashboard() {
+  const [filterText, setFilterText] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const [warningVisible, setWarningVisible] = useState(true);
+  const [selectedDevices, setSelectedDevices] = useState<Device[]>([]);
+
+  const filteredDevices = allDevices.filter(
+    device =>
+      device.name.toLowerCase().includes(filterText.toLowerCase()) ||
+      device.type.toLowerCase().includes(filterText.toLowerCase()) ||
+      device.ipAddress.includes(filterText) ||
+      device.status.toLowerCase().includes(filterText.toLowerCase()),
+  );
+
+  const pagedDevices = filteredDevices.slice((currentPage - 1) * DEVICES_PER_PAGE, currentPage * DEVICES_PER_PAGE);
+
+  return (
+    <AppLayout
+      navigationHide
+      toolsHide
+      breadcrumbs={
+        <BreadcrumbGroup
+          items={[
+            { text: 'Service', href: '/' },
+            { text: 'Administrative Dashboard', href: '/network-dashboard' },
+          ]}
+          ariaLabel="Breadcrumbs"
+        />
+      }
+      content={
+        <ContentLayout
+          header={
+            <SpaceBetween size="m">
+              <Header
+                variant="h1"
+                description="Network Traffic, Credit Usage, and Your Devices"
+                actions={
+                  <Button variant="primary" iconAlign="right" iconName="external">
+                    Refresh Data
+                  </Button>
+                }
+              >
+                Network Administration Dashboard
+              </Header>
+
+              <SpaceBetween size="s" direction="horizontal">
+                <div className="network-dashboard__filter-row">
+                  <TextFilter
+                    filteringText={filterText}
+                    filteringPlaceholder="Placeholder"
+                    filteringAriaLabel="Filter devices"
+                    onChange={({ detail }) => {
+                      setFilterText(detail.filteringText);
+                      setCurrentPage(1);
+                    }}
+                  />
+                  <Pagination
+                    currentPageIndex={currentPage}
+                    pagesCount={Math.ceil(filteredDevices.length / DEVICES_PER_PAGE)}
+                    onChange={({ detail }) => setCurrentPage(detail.currentPageIndex)}
+                    ariaLabels={{
+                      nextPageLabel: 'Next page',
+                      previousPageLabel: 'Previous page',
+                      pageLabel: pageNumber => `Page ${pageNumber}`,
+                    }}
+                  />
+                </div>
+              </SpaceBetween>
+
+              {warningVisible && (
+                <Flashbar
+                  items={[
+                    {
+                      type: 'warning',
+                      content: 'This is a warning message',
+                      dismissible: true,
+                      onDismiss: () => setWarningVisible(false),
+                      id: 'network-warning',
+                    },
+                  ]}
+                />
+              )}
+            </SpaceBetween>
+          }
+        >
+          <SpaceBetween size="l">
+            <Grid
+              gridDefinition={[
+                { colspan: { default: 12, m: 6 } },
+                { colspan: { default: 12, m: 6 } },
+              ]}
+            >
+              <Container>
+                <AreaChart
+                  series={[
+                    {
+                      title: 'Site 1',
+                      type: 'area',
+                      data: networkTrafficData.site1,
+                      color: '#688AE8',
+                    },
+                    {
+                      title: 'Site 2',
+                      type: 'area',
+                      data: networkTrafficData.site2,
+                      color: '#C33D69',
+                    },
+                    {
+                      title: 'Performance goal',
+                      type: 'threshold',
+                      y: 3.5,
+                      color: '#5F6B7A',
+                    },
+                  ]}
+                  xScaleType="categorical"
+                  xTitle="Day"
+                  yTitle="Network traffic"
+                  height={280}
+                  hideFilter
+                  ariaLabel="Network traffic area chart"
+                  ariaDescription="Area chart showing network traffic for Site 1 and Site 2 over 12 days with performance goal threshold."
+                  i18nStrings={{
+                    filterLabel: 'Filter displayed series',
+                    filterPlaceholder: 'Filter series',
+                    filterSelectedAriaLabel: 'selected',
+                    legendAriaLabel: 'Legend',
+                    chartAriaRoleDescription: 'area chart',
+                    detailPopoverDismissAriaLabel: 'Dismiss',
+                    xTickFormatter: value => String(value),
+                    yTickFormatter: value => `y${value}`,
+                  }}
+                />
+              </Container>
+
+              <Container>
+                <BarChart
+                  series={[
+                    {
+                      title: 'Site 1',
+                      type: 'bar',
+                      data: creditUsageData,
+                      color: '#688AE8',
+                    },
+                    {
+                      title: 'Performance goal',
+                      type: 'threshold',
+                      y: 4.0,
+                      color: '#5F6B7A',
+                    },
+                  ]}
+                  xScaleType="categorical"
+                  xTitle="Day"
+                  yTitle="Credit Usage"
+                  height={280}
+                  hideFilter
+                  ariaLabel="Credit usage bar chart"
+                  ariaDescription="Bar chart showing credit usage for Site 1 over 5 periods with performance goal threshold."
+                  i18nStrings={{
+                    filterLabel: 'Filter displayed series',
+                    filterPlaceholder: 'Filter series',
+                    filterSelectedAriaLabel: 'selected',
+                    legendAriaLabel: 'Legend',
+                    chartAriaRoleDescription: 'bar chart',
+                    detailPopoverDismissAriaLabel: 'Dismiss',
+                    xTickFormatter: value => String(value),
+                    yTickFormatter: value => `y${value}`,
+                  }}
+                />
+              </Container>
+            </Grid>
+
+            <Table
+              header={
+                <Header
+                  variant="h2"
+                  description="Devices on your local network"
+                  actions={
+                    <Button variant="primary" iconAlign="right" iconName="external">
+                      Add Device
+                    </Button>
+                  }
+                >
+                  My Devices
+                </Header>
+              }
+              columnDefinitions={[
+                {
+                  id: 'name',
+                  header: 'Device Name',
+                  cell: item => item.name,
+                  sortingField: 'name',
+                  minWidth: 140,
+                },
+                {
+                  id: 'type',
+                  header: 'Device Type',
+                  cell: item => item.type,
+                  sortingField: 'type',
+                  minWidth: 140,
+                },
+                {
+                  id: 'ipAddress',
+                  header: 'IP Address',
+                  cell: item => item.ipAddress,
+                  minWidth: 140,
+                },
+                {
+                  id: 'status',
+                  header: 'Status',
+                  cell: item => item.status,
+                  sortingField: 'status',
+                  minWidth: 140,
+                },
+                {
+                  id: 'lastSeen',
+                  header: 'Last Seen',
+                  cell: item => item.lastSeen,
+                  minWidth: 140,
+                },
+                {
+                  id: 'bandwidth',
+                  header: 'Bandwidth',
+                  cell: item => item.bandwidth,
+                  minWidth: 140,
+                },
+                {
+                  id: 'location',
+                  header: 'Location',
+                  cell: item => item.location,
+                  sortingField: 'location',
+                  minWidth: 140,
+                },
+              ]}
+              items={pagedDevices}
+              selectionType="multi"
+              selectedItems={selectedDevices}
+              onSelectionChange={({ detail }) => setSelectedDevices(detail.selectedItems)}
+              trackBy="id"
+              empty={
+                <Box textAlign="center" color="inherit" margin={{ top: 'xxl', bottom: 'xxl' }}>
+                  <Box variant="h3">No devices found</Box>
+                  <Box variant="p">No devices match your filter criteria.</Box>
+                </Box>
+              }
+              pagination={
+                <Pagination
+                  currentPageIndex={currentPage}
+                  pagesCount={Math.ceil(filteredDevices.length / DEVICES_PER_PAGE)}
+                  onChange={({ detail }) => setCurrentPage(detail.currentPageIndex)}
+                  ariaLabels={{
+                    nextPageLabel: 'Next page',
+                    previousPageLabel: 'Previous page',
+                    pageLabel: pageNumber => `Page ${pageNumber}`,
+                  }}
+                />
+              }
+              filter={
+                <TextFilter
+                  filteringText={filterText}
+                  filteringPlaceholder="Find devices"
+                  filteringAriaLabel="Filter devices"
+                  countText={`${filteredDevices.length} matches`}
+                  onChange={({ detail }) => {
+                    setFilterText(detail.filteringText);
+                    setCurrentPage(1);
+                  }}
+                />
+              }
+              ariaLabels={{
+                selectionGroupLabel: 'Device selection',
+                allItemsSelectionLabel: () => 'select all',
+                itemSelectionLabel: ({ selectedItems }, item) =>
+                  `${item.name} is ${selectedItems.indexOf(item) >= 0 ? '' : 'not '}selected`,
+              }}
+            />
+          </SpaceBetween>
+        </ContentLayout>
+      }
+    />
+  );
+}

--- a/src/pages/network-dashboard/index.tsx
+++ b/src/pages/network-dashboard/index.tsx
@@ -116,6 +116,7 @@ export default function NetworkDashboard() {
         <ContentLayout
           header={
             <SpaceBetween size="m">
+              <div className="network-dashboard__page-title">
               <Header
                 variant="h1"
                 description="Network Traffic, Credit Usage, and Your Devices"
@@ -127,6 +128,7 @@ export default function NetworkDashboard() {
               >
                 Network Administration Dashboard
               </Header>
+              </div>
 
               <SpaceBetween size="s" direction="horizontal">
                 <div className="network-dashboard__filter-row">
@@ -156,7 +158,7 @@ export default function NetworkDashboard() {
                 <Flashbar
                   items={[
                     {
-                      type: 'warning',
+                      type: 'error',
                       content: 'This is a warning message',
                       dismissible: true,
                       onDismiss: () => setWarningVisible(false),

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -88,3 +88,19 @@ ul.menu-list {
     }
   }
 }
+
+.network-dashboard__filter-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+
+  > *:first-child {
+    flex: 1 1 300px;
+  }
+
+  @media only screen and (max-width: 600px) {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -89,6 +89,13 @@ ul.menu-list {
   }
 }
 
+.network-dashboard__page-title {
+  h1 span {
+    font-weight: 400 !important;
+    padding-left: 20px;
+  }
+}
+
 .network-dashboard__filter-row {
   display: flex;
   align-items: center;


### PR DESCRIPTION
### Summary
Adds a new Network Administration Dashboard page that visualizes network traffic, credit usage, and device management in a responsive Cloudscape-based layout.

### Problem
There was no dedicated network dashboard in the application to monitor network traffic across sites, track credit usage, and manage connected devices from a single view.

### Solution
Created a new `/network-dashboard` route using Cloudscape Design System components, translating the provided Figma design into a fully responsive page with charts and a paginated device table.

### Key Changes
- **New page** at `src/pages/network-dashboard/index.tsx` implementing the full dashboard UI with:
  - An `AreaChart` showing network traffic for Site 1 and Site 2 over time with a performance goal threshold
  - A `BarChart` showing credit usage with a performance goal threshold
  - A paginated, filterable, multi-select `Table` listing 50 mock devices with columns for name, type, IP address, status, last seen, bandwidth, and location
  - A dismissible `Flashbar` warning message in the page header
  - Breadcrumb navigation and a "Refresh Data" action button
- **Responsive layout** using Cloudscape `Grid` (two-column on medium+ screens, stacked on mobile) and custom SCSS utilities
- **New SCSS styles** in `base.scss` for `.network-dashboard__page-title` and `.network-dashboard__filter-row` (flexbox-based filter/pagination row with mobile breakpoint handling)
- **Registered the new route** in `src/pages/index.tsx` under the "Dashboards" category


---

<a href="https://builder.io/app/projects/82a0d72280b64a4e9c841241494d5ab4/cotton-talon-r4kk9rav"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://82a0d72280b64a4e9c841241494d5ab4-cotton-talon-r4kk9rav_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 46`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>82a0d72280b64a4e9c841241494d5ab4</projectId>-->
<!--<branchName>cotton-talon-r4kk9rav</branchName>-->